### PR TITLE
feat: refresh UI and harden KV endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upah Tukang — Cloudflare Pages (Functions + KV)
 
-UI sederhana (HTML/JS + Tailwind CDN) dengan backend **Cloudflare Pages Functions** memakai **KV binding `UPAH_KV`**.
+UI responsif (HTML/JS + Tailwind CDN) dengan backend **Cloudflare Pages Functions** memakai **KV binding `UPAH_KV`**.
 
 ## Fitur utama
 - Tiga halaman: `index.html`, `form.html`, `rekap.html` — tampilan seragam, mobile-first.
@@ -9,7 +9,7 @@ UI sederhana (HTML/JS + Tailwind CDN) dengan backend **Cloudflare Pages Function
   - `GET /api/list?prefix=...&cursor=...`
 - **Autosave** di form (debounce 800ms) + indikator waktu simpan.
 - Export **CSV/XLSX** (SheetJS CDN).
-- Rekap: filter sederhana, paginasi (client-side), hapus item, link kembali ke form (deep-link).
+- Rekap: filter periode/rumah/pencarian, paginasi (20/baris), ekspor gabungan + hapus tanpa reload, link kembali ke form (deep-link).
 
 ## Struktur
 ```
@@ -29,15 +29,23 @@ UI sederhana (HTML/JS + Tailwind CDN) dengan backend **Cloudflare Pages Function
 ## Deploy Cloudflare Pages
 1. Buat proyek **Pages** → **Connect to Git** (atau upload).
 2. Build command: **(kosong)** · Output dir: **root**.
-3. **Settings → Functions → KV bindings**:
+3. **Settings → Functions → KV bindings** (atur untuk **Production** dan **Preview**):
    - Name: `UPAH_KV`
-   - Namespace: pilih/baru (mis. `upah_tukang_kv`)
-4. Deploy. Coba endpoint:
-   - `GET {"your-domain"}/api/list?prefix=ut:snap:`
-   - `POST {"your-domain"}/api/state` (body: `{"key":"ut:snap:2025-01-01:2025-01-07:BlokA-01:<module 'uuid' from '/usr/local/lib/python3.11/uuid.py'>","value":{"contoh":true}}`)
+   - Namespace: pilih yang sudah ada atau buat baru (mis. `upah_tukang_kv`).
+4. Deploy. Uji endpoint dasar:
+   - `GET https://<domain-pages>/api/list?prefix=ut:snap:`
+   - `POST https://<domain-pages>/api/state` dengan body:
+     ```json
+     {
+       "key": "ut:snap:2025-01-01:2025-01-07:BlokA-01:uuid-random",
+       "value": { "contoh": true },
+       "meta": { "updatedAt": "2025-01-01T00:00:00.000Z" }
+     }
+     ```
 
 ## Catatan
 - Batas ukuran value default dibatasi di fungsi (±200 KB). Ubah sesuai kebutuhan.
-- `list` hanya mengembalikan **keys + metadata**. Untuk agregat penuh, klien melakukan `GET` per key (di `rekap.html`).
+- `list` hanya mengembalikan **keys + metadata**. Untuk data lama tanpa metadata lengkap, halaman rekap otomatis mengambil detail.
+- Semua fetch menggunakan `/api/state` & `/api/list` (tidak ada jalur Netlify).
 
 Lisensi: MIT

--- a/assets/css/extra.css
+++ b/assets/css/extra.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.toast-container {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.toast-item {
+  min-width: 220px;
+  max-width: 320px;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  color: #fff;
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 15px 35px -15px rgba(15, 23, 42, 0.6);
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.toast-item.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast-item.success {
+  background: rgba(21, 128, 61, 0.95);
+}
+
+.toast-item.error {
+  background: rgba(220, 38, 38, 0.95);
+}
+
+.toast-item.warning {
+  background: rgba(234, 179, 8, 0.95);
+  color: rgba(30, 41, 59, 1);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.15rem 0.6rem;
+  background-color: rgba(15, 118, 110, 0.12);
+  color: rgb(13 148 136);
+}
+
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.75rem;
+  background: linear-gradient(90deg, rgba(226,232,240,0.7) 25%, rgba(203,213,225,0.9) 37%, rgba(226,232,240,0.7) 63%);
+  background-size: 400% 100%;
+  animation: shimmer 1.4s ease infinite;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -1,0 +1,178 @@
+const RETRY_DELAYS = [0, 600, 1400];
+
+async function jsonRequest(path, { method = 'GET', body, retryDelays = RETRY_DELAYS } = {}) {
+  let lastErr = null;
+  for (let attempt = 0; attempt < retryDelays.length; attempt++) {
+    const wait = retryDelays[attempt];
+    if (wait) {
+      await new Promise((resolve) => setTimeout(resolve, wait));
+    }
+    try {
+      const opts = { method, headers: { 'Accept': 'application/json' }, credentials: 'same-origin' };
+      if (body !== undefined) {
+        opts.body = JSON.stringify(body);
+        opts.headers['Content-Type'] = 'application/json';
+      }
+      const res = await fetch(path, opts);
+      const text = await res.text();
+      const data = text ? JSON.parse(text) : {};
+      if (!res.ok || data?.ok === false) {
+        const msg = data?.error || res.statusText || 'Request gagal';
+        throw new Error(msg);
+      }
+      return data;
+    } catch (err) {
+      lastErr = err;
+      if (attempt === retryDelays.length - 1) {
+        throw err;
+      }
+    }
+  }
+  throw lastErr || new Error('Gagal memuat');
+}
+
+export const API = {
+  async get(key) {
+    if (!key) throw new Error('key wajib');
+    return jsonRequest(`/api/state?key=${encodeURIComponent(key)}`);
+  },
+  async set(key, value, meta = {}) {
+    if (!key) throw new Error('key wajib');
+    return jsonRequest('/api/state', { method: 'POST', body: { key, value, meta } });
+  },
+  async del(key) {
+    if (!key) throw new Error('key wajib');
+    return jsonRequest(`/api/state?key=${encodeURIComponent(key)}`, { method: 'DELETE' });
+  },
+  async list(prefix, cursor = '', limit = 50) {
+    const search = new URLSearchParams();
+    if (prefix) search.set('prefix', prefix);
+    if (cursor) search.set('cursor', cursor);
+    if (limit) search.set('limit', String(limit));
+    return jsonRequest(`/api/list?${search.toString()}`);
+  }
+};
+
+export const utils = {
+  debounce(fn, wait = 300) {
+    let timer;
+    return function debounced(...args) {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn.apply(this, args), wait);
+    };
+  },
+  formatRupiah(value) {
+    const n = Number(value) || 0;
+    return new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR', maximumFractionDigits: 0 }).format(n);
+  },
+  formatNumber(value) {
+    const n = Number(value) || 0;
+    return new Intl.NumberFormat('id-ID').format(n);
+  },
+  todayISO() {
+    return new Date().toISOString().slice(0, 10);
+  },
+  plusDaysISO(date, add = 0) {
+    if (!date) return '';
+    const d = new Date(date);
+    if (Number.isNaN(d.getTime())) return '';
+    d.setDate(d.getDate() + add);
+    return d.toISOString().slice(0, 10);
+  },
+  uuid() {
+    if (crypto?.randomUUID) return crypto.randomUUID();
+    return 'xxxxxx4xyx'.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  },
+  parseSnapshotKey(key = '') {
+    const parts = key.split(':');
+    return {
+      raw: key,
+      start: parts[2] || '',
+      end: parts[3] || '',
+      rumah: parts[4] || '',
+      uuid: parts[5] || ''
+    };
+  },
+  toCSV(filename, rows) {
+    if (!rows?.length) throw new Error('Tidak ada data untuk diexport');
+    const headers = Object.keys(rows[0]);
+    const escape = (val) => {
+      if (val === null || val === undefined) return '';
+      const str = String(val).replace(/\r?\n/g, ' ');
+      if (/[",;\n]/.test(str)) {
+        return `"${str.replace(/"/g, '""')}"`;
+      }
+      return str;
+    };
+    const csv = [headers.join(',')].concat(rows.map((row) => headers.map((h) => escape(row[h])).join(','))).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  },
+  toXLSX(filename, sheets) {
+    if (!window.XLSX) throw new Error('SheetJS belum dimuat');
+    const wb = XLSX.utils.book_new();
+    Object.entries(sheets).forEach(([name, rows]) => {
+      const sheet = XLSX.utils.json_to_sheet(rows);
+      XLSX.utils.book_append_sheet(wb, sheet, name.slice(0, 31));
+    });
+    XLSX.writeFile(wb, filename, { compression: true });
+  },
+  sumRows(rows = []) {
+    return rows.reduce((acc, row) => acc + ((Number(row.tarif) || 0) * (Number(row.hari) || 0)), 0);
+  },
+  sumDays(rows = []) {
+    return rows.reduce((acc, row) => acc + (Number(row.hari) || 0), 0);
+  },
+  parseCSV(text) {
+    const rows = [];
+    const lines = text.split(/\r?\n/).filter((line) => line.trim().length);
+    if (!lines.length) {
+      return { headers: [], rows: [] };
+    }
+    const headers = lines[0].split(',').map((h) => h.trim());
+    for (let i = 1; i < lines.length; i++) {
+      const cells = lines[i].split(',');
+      const obj = {};
+      headers.forEach((h, idx) => {
+        obj[h] = (cells[idx] ?? '').trim();
+      });
+      rows.push(obj);
+    }
+    return { headers, rows };
+  }
+};
+
+export function showToast(message, type = 'info') {
+  const containerId = 'toast-container';
+  let container = document.getElementById(containerId);
+  if (!container) {
+    container = document.createElement('div');
+    container.id = containerId;
+    container.className = 'toast-container';
+    container.setAttribute('aria-live', 'polite');
+    document.body.appendChild(container);
+  }
+  const item = document.createElement('div');
+  item.className = `toast-item show ${type}`;
+  item.textContent = message;
+  container.appendChild(item);
+  setTimeout(() => {
+    item.classList.remove('show');
+    setTimeout(() => item.remove(), 200);
+  }, 2800);
+}
+
+export function formatError(err) {
+  if (!err) return 'Terjadi kesalahan';
+  if (typeof err === 'string') return err;
+  return err.message || 'Terjadi kesalahan tak diketahui';
+}

--- a/form.html
+++ b/form.html
@@ -3,183 +3,460 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Upah Tukang — Form</title>
+  <title>Upah Tukang — Form 7 Hari</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/extra.css">
 </head>
 <body class="bg-slate-50 text-slate-800">
-  <header class="sticky top-0 z-10 bg-white/90 backdrop-blur border-b">
-    <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-      <a href="/index.html" class="text-sm text-slate-600">&larr; Beranda</a>
-      <h1 class="text-lg font-semibold">Form Upah 7 Hari</h1>
-      <div class="text-xs text-slate-500"><span id="saveState">Belum tersimpan</span></div>
+  <header class="sticky top-0 z-20 border-b bg-white/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-3">
+      <div class="flex items-center gap-3">
+        <a href="/index.html" class="rounded-xl border border-transparent px-3 py-2 text-sm text-slate-500 transition hover:border-slate-200 hover:text-slate-700">&larr; Beranda</a>
+        <div>
+          <p class="text-xs uppercase tracking-wide text-slate-400">Upah Tukang</p>
+          <h1 class="text-lg font-semibold">Form 7 Hari</h1>
+        </div>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <span id="saveState" class="rounded-full bg-emerald-100 px-3 py-1 font-medium text-emerald-700">Siap</span>
+        <span id="offline" class="hidden rounded-full bg-red-100 px-3 py-1 font-medium text-red-600">Offline</span>
+      </div>
     </div>
   </header>
 
-  <main class="max-w-5xl mx-auto px-4 py-6 space-y-6">
-    <section class="bg-white rounded-2xl shadow-sm p-4 space-y-4">
-      <div class="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <div>
-          <label class="block text-xs text-slate-500 mb-1">Periode (Mulai)</label>
-          <input id="start" type="date" class="w-full border rounded-xl px-3 py-2">
-        </div>
-        <div>
-          <label class="block text-xs text-slate-500 mb-1">s/d (Otomatis +6)</label>
-          <input id="end" type="date" class="w-full border rounded-xl px-3 py-2" disabled>
-        </div>
-        <div>
-          <label class="block text-xs text-slate-500 mb-1">Rumah</label>
-          <input id="rumah" type="text" placeholder="BlokA-01" class="w-full border rounded-xl px-3 py-2">
-        </div>
-        <div class="flex items-end gap-2">
-          <button id="btnSave" class="px-3 py-2 rounded-xl bg-slate-900 text-white">Simpan</button>
-          <button id="btnClear" class="px-3 py-2 rounded-xl border">Kosongkan</button>
-          <button id="btnExport" class="px-3 py-2 rounded-xl border">Export</button>
+  <main class="mx-auto max-w-6xl space-y-8 px-4 py-6">
+    <section class="rounded-2xl bg-white p-6 shadow-sm">
+      <div class="grid gap-4 md:grid-cols-4">
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-400">Periode (Mulai)</span>
+          <input id="start" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" required>
+        </label>
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-400">s/d (otomatis +6)</span>
+          <input id="end" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 bg-slate-50" readonly>
+        </label>
+        <label class="flex flex-col gap-1 text-sm">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-400">Rumah</span>
+          <input id="rumah" type="text" placeholder="BlokA-01" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
+        </label>
+        <div class="flex flex-wrap items-center justify-end gap-2">
+          <button id="btnSave" class="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-500">Simpan</button>
+          <button id="btnClear" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-600 hover:border-slate-300">Kosongkan</button>
         </div>
       </div>
-      <input id="key" type="hidden">
+      <div class="mt-4 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <input id="key" type="hidden">
+        <button id="btnExportXLSX" class="rounded-xl border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300">Export XLSX</button>
+        <button id="btnExportCSV" class="rounded-xl border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300">Export CSV</button>
+        <label for="importCsv" class="cursor-pointer rounded-xl border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:border-slate-300">Import CSV</label>
+        <input id="importCsv" type="file" accept=".csv" class="hidden">
+        <span class="text-slate-300">|</span>
+        <span id="lastSaved" class="text-xs text-slate-400">—</span>
+      </div>
     </section>
 
-    <section class="bg-white rounded-2xl shadow-sm p-4 space-y-3">
-      <div class="flex items-center justify-between">
-        <h2 class="text-base font-semibold">Daftar Tukang (7 hari)</h2>
-        <button id="btnAddRow" class="px-3 py-2 rounded-xl border">Tambah Baris</button>
+    <section class="space-y-4 rounded-2xl bg-white p-6 shadow-sm">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 class="text-base font-semibold text-slate-900">Daftar Tukang</h2>
+          <p class="text-xs text-slate-500">Isi tarif per hari dan jumlah hari kerja (maksimal 7 hari).</p>
+        </div>
+        <button id="btnAddRow" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 hover:border-slate-300">Tambah Baris</button>
       </div>
-      <div class="overflow-x-auto">
-        <table class="min-w-full text-sm" id="tbl">
+      <div id="tableWrap" class="table-scroll">
+        <table class="min-w-full text-sm">
           <thead class="text-left text-slate-500">
             <tr>
-              <th class="py-2 pr-3">Nama</th>
-              <th class="py-2 pr-3">Tarif/Hari</th>
-              <th class="py-2 pr-3">Hari Kerja</th>
-              <th class="py-2 pr-3">Total</th>
-              <th class="py-2 pr-3">Aksi</th>
+              <th class="py-2 pr-3 font-medium">Nama</th>
+              <th class="py-2 pr-3 font-medium">Tarif/Hari</th>
+              <th class="py-2 pr-3 font-medium">Hari Kerja</th>
+              <th class="py-2 pr-3 font-medium text-right">Total</th>
+              <th class="py-2 pr-3 font-medium text-right">Aksi</th>
             </tr>
           </thead>
-          <tbody id="tbody"></tbody>
+          <tbody id="tbody" class="divide-y divide-slate-100"></tbody>
         </table>
+      </div>
+      <div class="grid gap-3 md:grid-cols-3">
+        <div class="rounded-2xl bg-slate-50 p-4">
+          <p class="text-xs uppercase tracking-wide text-slate-400">Total Baris</p>
+          <p id="totalRows" class="text-xl font-semibold text-slate-800">0</p>
+        </div>
+        <div class="rounded-2xl bg-slate-50 p-4">
+          <p class="text-xs uppercase tracking-wide text-slate-400">Total Hari Kerja</p>
+          <p id="totalDays" class="text-xl font-semibold text-slate-800">0</p>
+        </div>
+        <div class="rounded-2xl bg-slate-50 p-4">
+          <p class="text-xs uppercase tracking-wide text-slate-400">Total Upah</p>
+          <p id="totalAmount" class="text-xl font-semibold text-slate-800">Rp0</p>
+        </div>
       </div>
     </section>
   </main>
 
-  <div id="toast" class="toast bg-slate-900 text-white px-3 py-2 rounded-xl"></div>
+  <footer class="border-t bg-white/80 py-4">
+    <div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
+      <span>&copy; <span id="year"></span> Upah Tukang</span>
+      <span>Autosave aktif • Data tersimpan di <code>UPAH_KV</code></span>
+    </div>
+  </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { API, utils } from '/assets/js/config.js';
-    const $ = (s)=>document.querySelector(s);
-    const toast = (m)=>{ const t=$('#toast'); t.textContent=m; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'),1500); };
-    const setEnd = ()=> $('#end').value = utils.plusDaysISO($('#start').value, 6);
+    import { API, utils, showToast, formatError } from '/assets/js/config.js';
 
-    const rowTpl = (r,i)=>`
-      <tr data-i="${i}">
-        <td class="py-2 pr-3"><input class="nm w-full border rounded-xl px-2 py-1" value="${r.nama||''}"></td>
-        <td class="py-2 pr-3"><input class="tarif w-28 border rounded-xl px-2 py-1" type="number" min="0" value="${r.tarif||0}"></td>
-        <td class="py-2 pr-3"><input class="hari w-20 border rounded-xl px-2 py-1" type="number" min="0" max="7" value="${r.hari||0}"></td>
-        <td class="py-2 pr-3 total text-right">${utils.rupiah((+r.tarif||0)*(+r.hari||0))}</td>
-        <td class="py-2 pr-3"><button class="btnDelRow px-2 py-1 rounded border border-red-300 text-red-600">Hapus</button></td>
-      </tr>`;
+    const YEAR = new Date().getFullYear();
+    document.getElementById('year').textContent = YEAR;
 
-    const data = { rows: [] };
-    let dirty = false;
-    const markSaved = (ok)=>$('#saveState').textContent = ok ? ('Tersimpan • '+new Date().toLocaleTimeString()) : 'Menyimpan…';
+    const tbody = document.getElementById('tbody');
+    const saveState = document.getElementById('saveState');
+    const lastSaved = document.getElementById('lastSaved');
+    const offlineBadge = document.getElementById('offline');
 
-    function calcTotals(){
-      document.querySelectorAll('#tbody tr').forEach(tr=>{
-        const tarif = +tr.querySelector('.tarif').value||0;
-        const hari = +tr.querySelector('.hari').value||0;
-        tr.querySelector('.total').textContent = utils.rupiah(tarif*hari);
+    const state = {
+      key: '',
+      rows: [],
+      dirty: false,
+      saving: false,
+      loaded: false
+    };
+
+    function setOffline(isOffline) {
+      offlineBadge.classList.toggle('hidden', !isOffline);
+    }
+
+    function markSaving(pending) {
+      state.saving = pending;
+      if (pending) {
+        saveState.textContent = 'Menyimpan…';
+        saveState.className = 'rounded-full bg-amber-100 px-3 py-1 font-medium text-amber-700';
+      } else {
+        saveState.textContent = 'Tersimpan';
+        saveState.className = 'rounded-full bg-emerald-100 px-3 py-1 font-medium text-emerald-700';
+      }
+    }
+
+    function markDirty() {
+      state.dirty = true;
+      state.saving = false;
+      saveState.textContent = 'Draft belum tersimpan';
+      saveState.className = 'rounded-full bg-slate-200 px-3 py-1 font-medium text-slate-700';
+    }
+
+    function ensureRows() {
+      if (!state.rows.length) {
+        state.rows.push({ nama: '', tarif: 0, hari: 0 });
+      }
+    }
+
+    function renderRows() {
+      ensureRows();
+      tbody.innerHTML = '';
+      state.rows.forEach((row, index) => {
+        const isLocked = state.rows.length === 1;
+        const btnClasses = isLocked
+          ? 'btnDelRow rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-400 opacity-40 cursor-not-allowed'
+          : 'btnDelRow rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300';
+        const tr = document.createElement('tr');
+        tr.dataset.index = index;
+        tr.className = 'transition hover:bg-slate-50';
+        tr.innerHTML = `
+          <td class="py-2 pr-3">
+            <input class="nm w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" value="${row.nama || ''}" placeholder="Nama Tukang">
+          </td>
+          <td class="py-2 pr-3">
+            <input class="tarif w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" type="number" min="0" step="1000" value="${row.tarif ?? 0}" aria-label="Tarif per hari">
+          </td>
+          <td class="py-2 pr-3">
+            <input class="hari w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" type="number" min="0" max="7" value="${row.hari ?? 0}" aria-label="Jumlah hari kerja">
+          </td>
+          <td class="py-2 pr-3 text-right font-medium text-slate-800">${utils.formatRupiah((Number(row.tarif) || 0) * (Number(row.hari) || 0))}</td>
+          <td class="py-2 pr-3 text-right">
+            <button class="${btnClasses}" ${isLocked ? 'disabled' : ''}>Hapus</button>
+          </td>
+        `;
+        tbody.appendChild(tr);
       });
+      refreshSummary();
     }
 
-    function rebuildTable(){
-      const tbody = $('#tbody');
-      tbody.innerHTML = data.rows.map((r,i)=>rowTpl(r,i)).join('');
-      calcTotals();
+    function refreshSummary() {
+      const totalRows = state.rows.length;
+      const totalDays = utils.sumDays(state.rows);
+      const totalAmount = utils.sumRows(state.rows);
+      document.getElementById('totalRows').textContent = utils.formatNumber(totalRows);
+      document.getElementById('totalDays').textContent = utils.formatNumber(totalDays);
+      document.getElementById('totalAmount').textContent = utils.formatRupiah(totalAmount);
     }
 
-    function restoreDefaultRow(){
-      data.rows = [
-        { nama:'', tarif:0, hari:0 }
-      ];
-      rebuildTable();
-    }
-
-    function collect(){
-      const rows = Array.from(document.querySelectorAll('#tbody tr')).map(tr=>({
+    function collectForm() {
+      const rows = Array.from(tbody.querySelectorAll('tr')).map((tr) => ({
         nama: tr.querySelector('.nm').value.trim(),
-        tarif: +tr.querySelector('.tarif').value||0,
-        hari: +tr.querySelector('.hari').value||0
+        tarif: Math.max(0, Number(tr.querySelector('.tarif').value) || 0),
+        hari: Math.max(0, Math.min(7, Number(tr.querySelector('.hari').value) || 0))
       }));
-      const start = $('#start').value;
-      const end = $('#end').value;
-      const rumah = $('#rumah').value.trim();
+      state.rows = rows;
+      const start = document.getElementById('start').value;
+      const end = document.getElementById('end').value;
+      const rumah = document.getElementById('rumah').value.trim();
       return { start, end, rumah, rows };
     }
 
-    async function save(force=false){
-      const v = collect();
-      if(!v.start){ toast('Isi tanggal mulai'); return; }
-      if(!$('#key').value){
-        // buat key pertama kali
-        const uid = new URL(location.href).searchParams.get('new') || utils.uuid();
-        const rumahSeg = v.rumah ? v.rumah : '';
-        const key = `ut:snap:${v.start}:${v.end}:${rumahSeg}:${uid}`;
-        $('#key').value = key;
+    function validateForm(payload) {
+      if (!payload.start) {
+        throw new Error('Tanggal mulai wajib diisi');
       }
-      markSaved(false);
-      const meta = { updatedAt: new Date().toISOString(), start:v.start, end:v.end, rumah:v.rumah };
-      await API.set($('#key').value, v, meta);
-      markSaved(true);
-      dirty = false;
-    }
-
-    const debouncedSave = utils.debounce(()=>save(), 800);
-
-    // events
-    document.addEventListener('input', (e)=>{
-      if(e.target.matches('#start')){ setEnd(); }
-      if(e.target.closest('#tbody') || e.target.matches('#rumah') || e.target.matches('#start')){
-        dirty = true; calcTotals(); debouncedSave();
+      if (Number.isNaN(new Date(payload.start).getTime())) {
+        throw new Error('Tanggal mulai tidak valid');
       }
-    });
-    document.getElementById('btnSave').addEventListener('click', ()=>save(true));
-    document.getElementById('btnClear').addEventListener('click', ()=>{ restoreDefaultRow(); dirty=true; debouncedSave(); });
-    document.getElementById('btnAddRow').addEventListener('click', ()=>{ data.rows.push({nama:'',tarif:0,hari:0}); rebuildTable(); dirty=true; debouncedSave(); });
-    document.getElementById('btnExport').addEventListener('click', ()=>{
-      const v = collect();
-      const flat = v.rows.map((r,i)=>({ No:i+1, Nama:r.nama, Tarif:r.tarif, Hari:r.hari, Total:r.tarif*r.hari, Periode:`${v.start}→${v.end}`, Rumah:v.rumah }));
-      const sheets = { 'Upah 7 Hari': flat };
-      utils.toXLSX(`upah_${v.start}_${v.end}_${v.rumah||'NA'}.xlsx`, sheets);
-    });
-
-    // init
-    const url = new URL(location.href);
-    const key = url.searchParams.get('key');
-    const startQ = url.searchParams.get('start');
-    const endQ = url.searchParams.get('end');
-
-    $('#start').value = startQ || utils.todayISO();
-    setEnd();
-    if(endQ){ $('#end').value = endQ; }
-
-    if(key){
-      API.get(key).then(res=>{
-        if(res && res.value){
-          $('#key').value = key;
-          $('#start').value = res.value.start || $('#start').value;
-          $('#end').value = res.value.end || $('#end').value;
-          $('#rumah').value = res.value.rumah || '';
-          data.rows = Array.isArray(res.value.rows) ? res.value.rows : [];
-          if(!data.rows.length) restoreDefaultRow(); else rebuildTable();
-          markSaved(true);
-        } else {
-          restoreDefaultRow();
+      if (!payload.end || Number.isNaN(new Date(payload.end).getTime())) {
+        throw new Error('Tanggal selesai tidak valid');
+      }
+      payload.rows.forEach((row, idx) => {
+        if ((Number(row.tarif) || 0) < 0) {
+          throw new Error(`Tarif baris ${idx + 1} tidak boleh negatif`);
         }
-      }).catch(()=>restoreDefaultRow());
-    } else {
-      restoreDefaultRow();
+        if ((Number(row.hari) || 0) < 0) {
+          throw new Error(`Hari kerja baris ${idx + 1} tidak boleh negatif`);
+        }
+      });
     }
+
+    async function persist(manual = false) {
+      try {
+        const payload = collectForm();
+        validateForm(payload);
+        const total = utils.sumRows(payload.rows);
+        const totalDays = utils.sumDays(payload.rows);
+        if (!state.key) {
+          const idFromQuery = new URLSearchParams(window.location.search).get('new') || utils.uuid();
+          const rumahSegment = payload.rumah ? payload.rumah.replace(/:/g, '-').trim() : '';
+          if (payload.start && payload.end) {
+            state.key = `ut:snap:${payload.start}:${payload.end}:${rumahSegment}:${idFromQuery}`;
+          } else {
+            state.key = `ut:snap:${idFromQuery}`;
+          }
+          document.getElementById('key').value = state.key;
+        }
+        markSaving(true);
+        const meta = {
+          updatedAt: new Date().toISOString(),
+          start: payload.start,
+          end: payload.end,
+          rumah: payload.rumah,
+          total,
+          totalDays
+        };
+        await API.set(state.key, payload, meta);
+        state.dirty = false;
+        markSaving(false);
+        lastSaved.textContent = `Tersimpan ${new Date().toLocaleTimeString('id-ID')}`;
+        if (manual) {
+          showToast('Data berhasil disimpan', 'success');
+        }
+      } catch (err) {
+        if (manual) {
+          showToast(formatError(err), 'error');
+        }
+        markDirty();
+        throw err;
+      }
+    }
+
+    const debouncedSave = utils.debounce(() => {
+      if (!state.loaded) return;
+      if (!navigator.onLine) {
+        markDirty();
+        return;
+      }
+      persist(false).catch(() => {});
+    }, 800);
+
+    document.addEventListener('input', (event) => {
+      if (event.target.matches('#start')) {
+        const end = utils.plusDaysISO(event.target.value, 6);
+        document.getElementById('end').value = end;
+      }
+      if (event.target.closest('table') || event.target.matches('#start') || event.target.matches('#rumah')) {
+        markDirty();
+        refreshSummary();
+        debouncedSave();
+      }
+    });
+
+    tbody.addEventListener('click', (event) => {
+      if (event.target.matches('.btnDelRow')) {
+        event.preventDefault();
+        const tr = event.target.closest('tr');
+        const index = Number(tr.dataset.index);
+        if (state.rows.length <= 1) {
+          showToast('Minimal satu baris data', 'warning');
+          return;
+        }
+        state.rows.splice(index, 1);
+        renderRows();
+        markDirty();
+        debouncedSave();
+      }
+    });
+
+    document.getElementById('btnAddRow').addEventListener('click', () => {
+      state.rows.push({ nama: '', tarif: 0, hari: 0 });
+      renderRows();
+      markDirty();
+      debouncedSave();
+    });
+
+    document.getElementById('btnClear').addEventListener('click', () => {
+      if (!window.confirm('Kosongkan tabel? Data tersimpan tidak dihapus.')) return;
+      state.rows = [{ nama: '', tarif: 0, hari: 0 }];
+      renderRows();
+      markDirty();
+    });
+
+    document.getElementById('btnSave').addEventListener('click', async () => {
+      try {
+        await persist(true);
+      } catch (err) {
+        showToast(formatError(err), 'error');
+      }
+    });
+
+    document.getElementById('btnExportXLSX').addEventListener('click', () => {
+      try {
+        const payload = collectForm();
+        const rows = payload.rows.map((row, idx) => ({
+          No: idx + 1,
+          Nama: row.nama,
+          Tarif: row.tarif,
+          Hari: row.hari,
+          Total: (Number(row.tarif) || 0) * (Number(row.hari) || 0),
+          Periode: `${payload.start} s/d ${payload.end}`,
+          Rumah: payload.rumah
+        }));
+        const summary = [{
+          Periode: `${payload.start} s/d ${payload.end}`,
+          Rumah: payload.rumah,
+          TotalHari: utils.sumDays(payload.rows),
+          TotalUpah: utils.sumRows(payload.rows)
+        }];
+        utils.toXLSX(`upah_${payload.start || 'periode'}_${payload.rumah || 'umum'}.xlsx`, {
+          'Upah Mingguan': rows,
+          Rekap: summary
+        });
+        showToast('Berhasil membuat file XLSX', 'success');
+      } catch (err) {
+        showToast(formatError(err), 'error');
+      }
+    });
+
+    document.getElementById('btnExportCSV').addEventListener('click', () => {
+      try {
+        const payload = collectForm();
+        const rows = payload.rows.map((row, idx) => ({
+          No: idx + 1,
+          Nama: row.nama,
+          Tarif: row.tarif,
+          Hari: row.hari,
+          Total: (Number(row.tarif) || 0) * (Number(row.hari) || 0),
+          Periode: `${payload.start} s/d ${payload.end}`,
+          Rumah: payload.rumah
+        }));
+        utils.toCSV(`upah_${payload.start || 'periode'}_${payload.rumah || 'umum'}.csv`, rows);
+        showToast('Berhasil membuat file CSV', 'success');
+      } catch (err) {
+        showToast(formatError(err), 'error');
+      }
+    });
+
+    document.getElementById('importCsv').addEventListener('change', (event) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        try {
+          const text = String(e.target?.result || '');
+          const parsed = utils.parseCSV(text);
+          if (!parsed.rows.length) {
+            throw new Error('File CSV kosong');
+          }
+          state.rows = parsed.rows.map((row) => ({
+            nama: row.Nama || row.nama || '',
+            tarif: Number(row.Tarif ?? row.tarif ?? 0) || 0,
+            hari: Number(row.Hari ?? row.hari ?? 0) || 0
+          }));
+          renderRows();
+          markDirty();
+          debouncedSave();
+          showToast('Data CSV dimuat', 'success');
+        } catch (err) {
+          showToast(formatError(err), 'error');
+        }
+      };
+      reader.onerror = () => showToast('Gagal membaca file CSV', 'error');
+      reader.readAsText(file);
+      event.target.value = '';
+    });
+
+    window.addEventListener('online', () => {
+      setOffline(false);
+      if (state.dirty) {
+        debouncedSave();
+      }
+    });
+    window.addEventListener('offline', () => setOffline(true));
+
+    async function loadFromKey(key) {
+      try {
+        markSaving(true);
+        const res = await API.get(key);
+        if (!res || !res.value) {
+          throw new Error('Data tidak ditemukan');
+        }
+        state.key = key;
+        document.getElementById('key').value = key;
+        document.getElementById('start').value = res.value.start || utils.todayISO();
+        document.getElementById('end').value = res.value.end || utils.plusDaysISO(document.getElementById('start').value, 6);
+        document.getElementById('rumah').value = res.value.rumah || '';
+        state.rows = Array.isArray(res.value.rows) && res.value.rows.length ? res.value.rows : [{ nama: '', tarif: 0, hari: 0 }];
+        renderRows();
+        markSaving(false);
+        lastSaved.textContent = res.meta?.updatedAt ? `Terakhir ${new Date(res.meta.updatedAt).toLocaleString('id-ID')}` : '—';
+        state.loaded = true;
+        state.dirty = false;
+      } catch (err) {
+        markSaving(false);
+        showToast(formatError(err), 'error');
+        state.rows = [{ nama: '', tarif: 0, hari: 0 }];
+        renderRows();
+        state.loaded = true;
+      }
+    }
+
+    function initFromQuery() {
+      const params = new URLSearchParams(window.location.search);
+      const key = params.get('key');
+      const startParam = params.get('start');
+      const endParam = params.get('end');
+      if (key) {
+        loadFromKey(key).then(() => {
+          state.loaded = true;
+        });
+        return;
+      }
+      state.key = '';
+      document.getElementById('start').value = startParam || utils.todayISO();
+      document.getElementById('end').value = endParam || utils.plusDaysISO(document.getElementById('start').value, 6);
+      state.rows = [{ nama: '', tarif: 0, hari: 0 }];
+      renderRows();
+      state.loaded = true;
+    }
+
+    initFromQuery();
+    setOffline(!navigator.onLine);
   </script>
 </body>
 </html>

--- a/functions/api/list.js
+++ b/functions/api/list.js
@@ -1,0 +1,43 @@
+function jsonResponse(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store'
+    }
+  });
+}
+
+export async function onRequest(context) {
+  const { request, env } = context;
+  if (request.method.toUpperCase() !== 'GET') {
+    return jsonResponse({ ok: false, error: 'Metode tidak didukung' }, 405);
+  }
+  const url = new URL(request.url);
+  const prefix = url.searchParams.get('prefix') || '';
+  const cursor = url.searchParams.get('cursor') || undefined;
+  const limitParam = url.searchParams.get('limit');
+  let limit = Number.parseInt(limitParam, 10);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    limit = 50;
+  }
+  limit = Math.min(Math.max(limit, 1), 200);
+
+  try {
+    const listResult = await env.UPAH_KV.list({ prefix, cursor, limit });
+    const keys = (listResult.keys || []).map((entry) => ({
+      name: entry.name,
+      expiration: entry.expiration || null,
+      metadata: entry.metadata || {}
+    }));
+    return jsonResponse({
+      ok: true,
+      keys,
+      cursor: listResult.cursor || '',
+      list_complete: Boolean(listResult.list_complete)
+    });
+  } catch (err) {
+    console.error('api/list error', err);
+    return jsonResponse({ ok: false, error: 'Gagal mengambil daftar' }, 500);
+  }
+}

--- a/functions/api/state.js
+++ b/functions/api/state.js
@@ -1,0 +1,80 @@
+const MAX_VALUE_SIZE = 200 * 1024; // 200KB
+const ALLOWED_META_KEYS = ['updatedAt', 'start', 'end', 'rumah', 'total', 'totalDays'];
+
+function jsonResponse(data, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store'
+    }
+  });
+}
+
+export async function onRequest(context) {
+  const { request, env } = context;
+  const url = new URL(request.url);
+  const method = request.method.toUpperCase();
+
+  try {
+    if (method === 'GET') {
+      const key = url.searchParams.get('key');
+      if (!key) {
+        return jsonResponse({ ok: false, error: 'Parameter key wajib' }, 400);
+      }
+      const result = await env.UPAH_KV.getWithMetadata(key, { type: 'json' });
+      if (!result || result.value === null || result.value === undefined) {
+        return jsonResponse({ ok: false, error: 'Data tidak ditemukan' }, 404);
+      }
+      return jsonResponse({ ok: true, key, value: result.value, meta: result.metadata || {} });
+    }
+
+    if (method === 'POST') {
+      let payload;
+      try {
+        payload = await request.json();
+      } catch (err) {
+        return jsonResponse({ ok: false, error: 'Body harus JSON' }, 400);
+      }
+      const { key, value, meta = {} } = payload || {};
+      if (typeof key !== 'string' || !key.trim()) {
+        return jsonResponse({ ok: false, error: 'Key tidak valid' }, 400);
+      }
+      if (value === undefined) {
+        return jsonResponse({ ok: false, error: 'Value tidak boleh kosong' }, 400);
+      }
+
+      const stringified = JSON.stringify(value);
+      if (stringified.length > MAX_VALUE_SIZE) {
+        return jsonResponse({ ok: false, error: `Payload terlalu besar (maks ${MAX_VALUE_SIZE} byte)` }, 413);
+      }
+
+      const safeMeta = {};
+      if (meta && typeof meta === 'object') {
+        for (const keyName of ALLOWED_META_KEYS) {
+          if (meta[keyName] !== undefined) {
+            safeMeta[keyName] = meta[keyName];
+          }
+        }
+      }
+      safeMeta.valueSize = stringified.length;
+
+      await env.UPAH_KV.put(key, stringified, { metadata: safeMeta });
+      return jsonResponse({ ok: true, key, meta: safeMeta });
+    }
+
+    if (method === 'DELETE') {
+      const key = url.searchParams.get('key');
+      if (!key) {
+        return jsonResponse({ ok: false, error: 'Parameter key wajib' }, 400);
+      }
+      await env.UPAH_KV.delete(key);
+      return jsonResponse({ ok: true, key });
+    }
+
+    return jsonResponse({ ok: false, error: 'Metode tidak didukung' }, 405);
+  } catch (err) {
+    console.error('api/state error', err);
+    return jsonResponse({ ok: false, error: 'Terjadi kesalahan internal' }, 500);
+  }
+}

--- a/index.html
+++ b/index.html
@@ -3,118 +3,226 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Upah Tukang — Beranda</title>
+  <title>Upah Tukang — Dasbor</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/extra.css">
 </head>
 <body class="bg-slate-50 text-slate-800">
-  <header class="sticky top-0 z-10 bg-white/90 backdrop-blur border-b">
-    <div class="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-      <h1 class="text-xl font-semibold">Upah Tukang</h1>
-      <nav class="flex gap-2">
-        <a href="/rekap.html" class="px-3 py-2 rounded-xl border">Rekap</a>
-        <button id="btnNew" class="px-3 py-2 rounded-xl text-white bg-orange-500 hover:bg-orange-600">Form Baru</button>
+  <header class="sticky top-0 z-20 border-b bg-white/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-3">
+      <div>
+        <p class="text-xs uppercase tracking-wide text-slate-400">Upah Tukang</p>
+        <h1 class="text-lg font-semibold">Dasbor</h1>
+      </div>
+      <nav class="flex items-center gap-2 text-sm">
+        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="/rekap.html">Rekap</a>
+        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="/form.html">Isi Form</a>
+        <button id="btnNew" class="rounded-xl bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
       </nav>
     </div>
   </header>
 
-  <main class="max-w-5xl mx-auto px-4 py-6 space-y-6">
-    <section class="bg-white rounded-2xl shadow-sm p-4">
-      <h2 class="text-lg font-semibold mb-3">Terakhir Disimpan</h2>
-      <div id="listWrap" class="overflow-x-auto">
+  <main class="mx-auto max-w-6xl space-y-8 px-4 py-6">
+    <section class="grid gap-4 md:grid-cols-2">
+      <article class="rounded-2xl bg-white p-6 shadow-sm">
+        <h2 class="text-base font-semibold text-slate-900">Mulai Form Baru</h2>
+        <p class="mt-2 text-sm text-slate-500">Siapkan draft kosong dengan periode 7 hari ke depan. Data tersimpan otomatis di Cloudflare KV.</p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <button id="ctaNew" class="rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
+          <a href="/form.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Lanjutkan Draft</a>
+        </div>
+      </article>
+      <article class="rounded-2xl bg-white p-6 shadow-sm">
+        <h2 class="text-base font-semibold text-slate-900">Rekap & Ekspor</h2>
+        <p class="mt-2 text-sm text-slate-500">Pantau seluruh snapshot, filter sesuai kebutuhan, dan ekspor ke CSV/XLSX untuk arsip.</p>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <a href="/rekap.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Buka Rekap</a>
+          <span class="badge">Autosave aktif</span>
+        </div>
+      </article>
+    </section>
+
+    <section class="rounded-2xl bg-white p-6 shadow-sm">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 class="text-base font-semibold text-slate-900">Snapshot Terbaru</h2>
+          <p class="text-sm text-slate-500">Menampilkan 10 entri terakhir dengan informasi periode, rumah, dan total upah.</p>
+        </div>
+        <div class="flex items-center gap-2 text-xs text-slate-500">
+          <span id="listInfo">Memuat...</span>
+        </div>
+      </div>
+      <div id="emptyState" class="hidden rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">Belum ada data tersimpan. Mulai dari tombol <strong>Form Baru</strong>.</div>
+      <div id="tableWrap" class="mt-4 table-scroll">
         <table class="min-w-full text-sm">
           <thead class="text-left text-slate-500">
             <tr>
-              <th class="py-2 pr-4">Periode</th>
-              <th class="py-2 pr-4">Rumah</th>
-              <th class="py-2 pr-4">Updated</th>
-              <th class="py-2 pr-4">Aksi</th>
+              <th class="py-2 pr-4 font-medium">Periode</th>
+              <th class="py-2 pr-4 font-medium">Rumah</th>
+              <th class="py-2 pr-4 font-medium text-right">Total Upah</th>
+              <th class="py-2 pr-4 font-medium">Terakhir Disimpan</th>
+              <th class="py-2 pr-4 font-medium text-right">Aksi</th>
             </tr>
           </thead>
-          <tbody id="listBody"></tbody>
+          <tbody id="listBody" class="divide-y divide-slate-100"></tbody>
         </table>
-        <div class="flex items-center gap-2 mt-3">
-          <button id="prev" class="px-3 py-1 rounded border">Prev</button>
-          <button id="next" class="px-3 py-1 rounded border">Next</button>
-          <span id="cursorInfo" class="text-xs text-slate-500"></span>
+      </div>
+      <div id="skeleton" class="mt-4 space-y-2">
+        <div class="h-12 w-full skeleton"></div>
+        <div class="h-12 w-full skeleton"></div>
+        <div class="h-12 w-full skeleton"></div>
+      </div>
+      <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div class="flex items-center gap-2">
+          <button id="btnPrev" class="rounded-xl border border-slate-200 px-3 py-1.5 text-slate-600 hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-40">Sebelumnya</button>
+          <button id="btnNext" class="rounded-xl border border-slate-200 px-3 py-1.5 text-slate-600 hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-40">Berikutnya</button>
         </div>
+        <span id="cursorInfo" class="text-xs text-slate-400"></span>
       </div>
     </section>
   </main>
 
-  <div id="toast" class="toast bg-slate-900 text-white px-3 py-2 rounded-xl"></div>
+  <footer class="border-t bg-white/80 py-4">
+    <div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
+      <span>&copy; <span id="year"></span> Upah Tukang</span>
+      <span>Cloudflare Pages • KV binding <code>UPAH_KV</code></span>
+    </div>
+  </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { API, utils } from '/assets/js/config.js';
+    import { API, utils, showToast, formatError } from '/assets/js/config.js';
 
-    const toast = (msg)=>{
-      const el = document.getElementById('toast');
-      el.textContent = msg; el.classList.add('show');
-      setTimeout(()=>el.classList.remove('show'), 2000);
+    const YEAR = new Date().getFullYear();
+    document.getElementById('year').textContent = YEAR;
+
+    const state = {
+      cursor: '',
+      prev: [],
+      loading: false,
+      lastCursor: null
     };
 
-    // "Form Baru" → form.html?new={uuid}&start=today&sampai=+6
-    document.getElementById('btnNew').addEventListener('click', ()=>{
-      const start = utils.todayISO();
-      const end = utils.plusDaysISO(start, 6);
-      const id = utils.uuid();
-      const u = new URL('/form.html', location.origin);
-      u.searchParams.set('new', id);
-      u.searchParams.set('start', start);
-      u.searchParams.set('end', end);
-      location.href = u.toString();
-    });
+    const tableBody = document.getElementById('listBody');
+    const skeleton = document.getElementById('skeleton');
+    const emptyState = document.getElementById('emptyState');
+    const cursorInfo = document.getElementById('cursorInfo');
+    const listInfo = document.getElementById('listInfo');
 
-    let cursor = '';
-    async function loadList(){
-      const { ok, keys, cursor: c, list_complete } = await API.list('ut:snap:', cursor);
-      const body = document.getElementById('listBody');
-      body.innerHTML = '';
-      (keys||[]).slice(0,10).forEach(k=>{
-        // Expect name like ut:snap:YYYY-MM-DD:YYYY-MM-DD:rumah:uuid
-        const parts = (k.name||'').split(':');
-        const periode = parts[2] && parts[3] ? `${parts[2]} → ${parts[3]}` : '—';
-        const rumah = parts[4] || '—';
-        const updated = (k.metadata && k.metadata.updatedAt) ? new Date(k.metadata.updatedAt).toLocaleString() : '—';
-
-        const tr = document.createElement('tr');
-        tr.innerHTML = `
-          <td class="py-2 pr-4">${periode}</td>
-          <td class="py-2 pr-4">${rumah}</td>
-          <td class="py-2 pr-4">${updated}</td>
-          <td class="py-2 pr-4">
-            <a class="px-2 py-1 rounded border" href="/form.html?key=${encodeURIComponent(k.name)}">Buka</a>
-            <button data-key="${k.name}" class="btnDel px-2 py-1 rounded border border-red-300 text-red-600">Hapus</button>
-          </td>
-        `;
-        body.appendChild(tr);
-      });
-      document.getElementById('cursorInfo').textContent = list_complete ? 'last page' : (c ? `cursor: ${c.slice(0,8)}...` : '');
-      // Save next cursor
-      window._nextCursor = c || '';
+    function buildKeyInfo(key, metadata = {}) {
+      const { start, end, rumah } = utils.parseSnapshotKey(key);
+      const periode = start && end ? `${start} – ${end}` : 'Tidak diketahui';
+      const rumahLabel = rumah || metadata.rumah || '—';
+      const total = metadata.total ?? metadata.totalUpah ?? null;
+      const updatedAt = metadata.updatedAt ? new Date(metadata.updatedAt).toLocaleString('id-ID') : '—';
+      const totalLabel = total != null ? utils.formatRupiah(total) : '—';
+      return { periode, rumah: rumahLabel, updatedAt, totalLabel };
     }
 
-    document.getElementById('prev').addEventListener('click', ()=>{
-      toast('Cursor backward tidak disimpan (demo).');
-    });
-    document.getElementById('next').addEventListener('click', ()=>{
-      cursor = window._nextCursor || '';
+    function renderRows(keys = []) {
+      tableBody.innerHTML = '';
+      keys.forEach(({ name, metadata = {} }) => {
+        const info = buildKeyInfo(name, metadata || {});
+        const tr = document.createElement('tr');
+        tr.className = 'transition hover:bg-slate-50';
+        tr.innerHTML = `
+          <td class="py-3 pr-4 align-top">
+            <div class="font-medium text-slate-800">${info.periode}</div>
+            <div class="text-xs text-slate-400">${name}</div>
+          </td>
+          <td class="py-3 pr-4 align-top text-slate-700">${info.rumah}</td>
+          <td class="py-3 pr-4 align-top text-right font-medium text-slate-800">${info.totalLabel}</td>
+          <td class="py-3 pr-4 align-top text-slate-600">${info.updatedAt}</td>
+          <td class="py-3 pl-4 text-right">
+            <div class="flex justify-end gap-2">
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="/form.html?key=${encodeURIComponent(name)}">Buka</a>
+              <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-key="${name}">Hapus</button>
+            </div>
+          </td>
+        `;
+        tableBody.appendChild(tr);
+      });
+    }
+
+    async function loadList() {
+      if (state.loading) return;
+      try {
+        state.loading = true;
+        tableBody.innerHTML = '';
+        skeleton.classList.remove('hidden');
+        emptyState.classList.add('hidden');
+        listInfo.textContent = 'Memuat data...';
+        const { keys = [], cursor, list_complete } = await API.list('ut:snap:', state.cursor, 15);
+        skeleton.classList.add('hidden');
+        if (!keys.length && !state.cursor && !cursor) {
+          emptyState.classList.remove('hidden');
+          listInfo.textContent = 'Belum ada snapshot';
+          cursorInfo.textContent = '';
+          return;
+        }
+        renderRows(keys.slice(0, 10));
+        cursorInfo.textContent = list_complete ? 'Sudah halaman terakhir' : (cursor ? `Cursor ${cursor.slice(0, 8)}…` : '');
+        listInfo.textContent = `${Math.min(keys.length, 10)} dari ${keys.length} entri halaman ini`;
+        state.lastCursor = cursor || null;
+        document.getElementById('btnPrev').disabled = state.prev.length === 0;
+        document.getElementById('btnNext').disabled = list_complete;
+      } catch (err) {
+        skeleton.classList.add('hidden');
+        emptyState.classList.add('hidden');
+        showToast(formatError(err), 'error');
+        listInfo.textContent = 'Gagal memuat data';
+      } finally {
+        state.loading = false;
+      }
+    }
+
+    document.getElementById('btnPrev').addEventListener('click', () => {
+      if (!state.prev.length) return;
+      state.cursor = state.prev.pop() || '';
       loadList();
     });
 
-    document.addEventListener('click', async (e)=>{
-      if(e.target.matches('.btnDel')){
-        const key = e.target.getAttribute('data-key');
-        if(confirm('Hapus data ini?')){
+    document.getElementById('btnNext').addEventListener('click', () => {
+      if (!state.lastCursor) return;
+      state.prev.push(state.cursor);
+      state.cursor = state.lastCursor;
+      loadList();
+    });
+
+    document.addEventListener('click', async (event) => {
+      const target = event.target;
+      if (target.matches('button[data-key]')) {
+        const key = target.getAttribute('data-key');
+        const confirmed = window.confirm('Hapus snapshot ini? Data tidak dapat dikembalikan.');
+        if (!confirmed) return;
+        try {
           await API.del(key);
-          toast('Dihapus');
+          showToast('Snapshot dihapus', 'success');
           loadList();
+        } catch (err) {
+          showToast(formatError(err), 'error');
         }
       }
     });
 
-    loadList().catch(err=>toast(err.message));
+    function openNewForm() {
+      const start = utils.todayISO();
+      const end = utils.plusDaysISO(start, 6);
+      const id = utils.uuid();
+      const url = new URL('/form.html', window.location.origin);
+      url.searchParams.set('new', id);
+      url.searchParams.set('start', start);
+      url.searchParams.set('end', end);
+      window.location.href = url.toString();
+    }
+
+    document.getElementById('btnNew').addEventListener('click', openNewForm);
+    document.getElementById('ctaNew').addEventListener('click', openNewForm);
+
+    loadList();
   </script>
 </body>
 </html>

--- a/rekap.html
+++ b/rekap.html
@@ -5,148 +5,415 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Upah Tukang — Rekap</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/assets/css/extra.css">
 </head>
 <body class="bg-slate-50 text-slate-800">
-  <header class="sticky top-0 z-10 bg-white/90 backdrop-blur border-b">
-    <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-      <a href="/index.html" class="text-sm text-slate-600">&larr; Beranda</a>
-      <h1 class="text-lg font-semibold">Rekap</h1>
-      <div class="flex gap-2">
-        <input id="qRumah" placeholder="Cari rumah..." class="border rounded-xl px-3 py-2 text-sm">
-        <button id="btnExport" class="px-3 py-2 rounded-xl border">Export</button>
+  <header class="sticky top-0 z-20 border-b bg-white/90 backdrop-blur">
+    <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-3">
+      <div class="flex items-center gap-3">
+        <a href="/index.html" class="rounded-xl border border-transparent px-3 py-2 text-sm text-slate-500 transition hover:border-slate-200 hover:text-slate-700">&larr; Beranda</a>
+        <div>
+          <p class="text-xs uppercase tracking-wide text-slate-400">Upah Tukang</p>
+          <h1 class="text-lg font-semibold">Rekap Snapshot</h1>
+        </div>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 text-sm">
+        <button id="btnExportXLSX" class="rounded-xl border border-slate-200 px-3 py-2 font-medium text-slate-600 hover:border-slate-300">Export XLSX</button>
+        <button id="btnExportCSV" class="rounded-xl border border-slate-200 px-3 py-2 font-medium text-slate-600 hover:border-slate-300">Export CSV</button>
       </div>
     </div>
   </header>
 
-  <main class="max-w-6xl mx-auto px-4 py-6 space-y-6">
-    <section class="grid grid-cols-1 md:grid-cols-2 gap-3">
-      <div class="bg-white rounded-2xl shadow-sm p-4">
-        <div class="text-xs text-slate-500">Rekap Total</div>
-        <div class="text-2xl font-semibold" id="sumTotal">Rp0</div>
+  <main class="mx-auto max-w-6xl space-y-8 px-4 py-6">
+    <section class="rounded-2xl bg-white p-6 shadow-sm">
+      <div class="grid gap-4 lg:grid-cols-4">
+        <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Periode Mulai
+          <input id="filterStart" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
+        </label>
+        <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Periode Selesai
+          <input id="filterEnd" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
+        </label>
+        <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Rumah
+          <input id="filterRumah" type="text" placeholder="BlokA" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
+        </label>
+        <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          Pencarian Bebas
+          <input id="filterSearch" type="search" placeholder="kata kunci" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
+        </label>
       </div>
-      <div class="bg-white rounded-2xl shadow-sm p-4">
-        <div class="text-xs text-slate-500">Jumlah Snapshot</div>
-        <div class="text-2xl font-semibold" id="sumCount">0</div>
+      <div class="mt-4 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <span id="totalInfo">Memuat...</span>
+        <span class="text-slate-300">•</span>
+        <button id="btnReset" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 hover:border-slate-300">Reset Filter</button>
       </div>
     </section>
 
-    <section class="bg-white rounded-2xl shadow-sm p-4">
-      <div class="overflow-x-auto">
+    <section class="grid gap-4 md:grid-cols-2">
+      <article class="rounded-2xl bg-white p-6 shadow-sm">
+        <h2 class="text-base font-semibold text-slate-900">Total per Rumah</h2>
+        <p class="text-xs text-slate-500">Akumulasi total upah per rumah berdasarkan filter saat ini.</p>
+        <ul id="summaryRumah" class="mt-3 space-y-2 text-sm text-slate-700"></ul>
+      </article>
+      <article class="rounded-2xl bg-white p-6 shadow-sm">
+        <h2 class="text-base font-semibold text-slate-900">Total per Hari</h2>
+        <p class="text-xs text-slate-500">Akumulasi total upah berdasarkan tanggal mulai (periode).</p>
+        <ul id="summaryHari" class="mt-3 space-y-2 text-sm text-slate-700"></ul>
+      </article>
+    </section>
+
+    <section class="rounded-2xl bg-white p-6 shadow-sm">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 class="text-base font-semibold text-slate-900">Daftar Snapshot</h2>
+          <p class="text-xs text-slate-500">Klik tautan untuk membuka form sumber.</p>
+        </div>
+        <div class="text-xs text-slate-500" id="pageInfo">Halaman 1</div>
+      </div>
+      <div id="tableSkeleton" class="mt-4 space-y-2">
+        <div class="h-12 w-full skeleton"></div>
+        <div class="h-12 w-full skeleton"></div>
+        <div class="h-12 w-full skeleton"></div>
+      </div>
+      <div id="emptyState" class="mt-4 hidden rounded-xl border border-dashed border-slate-200 p-6 text-center text-sm text-slate-500">Tidak ada data sesuai filter.</div>
+      <div id="tableWrap" class="table-scroll hidden">
         <table class="min-w-full text-sm">
           <thead class="text-left text-slate-500">
             <tr>
-              <th class="py-2 pr-3">Periode</th>
-              <th class="py-2 pr-3">Rumah</th>
-              <th class="py-2 pr-3">Total (calc)</th>
-              <th class="py-2 pr-3">Updated</th>
-              <th class="py-2 pr-3">Aksi</th>
+              <th class="py-2 pr-4 font-medium">Periode</th>
+              <th class="py-2 pr-4 font-medium">Rumah</th>
+              <th class="py-2 pr-4 font-medium text-right">Total Upah</th>
+              <th class="py-2 pr-4 font-medium text-right">Total Hari</th>
+              <th class="py-2 pr-4 font-medium">Terakhir Disimpan</th>
+              <th class="py-2 pl-4 font-medium text-right">Aksi</th>
             </tr>
           </thead>
-          <tbody id="tbody"></tbody>
+          <tbody id="tableBody" class="divide-y divide-slate-100"></tbody>
         </table>
       </div>
-      <div class="flex items-center gap-2 mt-3">
-        <button id="prev" class="px-3 py-1 rounded border">Prev</button>
-        <button id="next" class="px-3 py-1 rounded border">Next</button>
-        <span id="cursorInfo" class="text-xs text-slate-500"></span>
+      <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div class="flex items-center gap-2">
+          <button id="btnPrev" class="rounded-xl border border-slate-200 px-3 py-1.5 text-slate-600 hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-40">Sebelumnya</button>
+          <button id="btnNext" class="rounded-xl border border-slate-200 px-3 py-1.5 text-slate-600 hover:border-slate-300 disabled:cursor-not-allowed disabled:opacity-40">Berikutnya</button>
+        </div>
+        <span id="cursorInfo" class="text-xs text-slate-400"></span>
       </div>
     </section>
   </main>
 
-  <div id="toast" class="toast bg-slate-900 text-white px-3 py-2 rounded-xl"></div>
+  <footer class="border-t bg-white/80 py-4">
+    <div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
+      <span>&copy; <span id="year"></span> Upah Tukang</span>
+      <span>Gunakan tombol hapus dengan hati-hati</span>
+    </div>
+  </footer>
 
-  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { API, utils } from '/assets/js/config.js';
-    const $ = (s)=>document.querySelector(s);
-    const toast = (m)=>{ const t=$('#toast'); t.textContent=m; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'),1500); };
+    import { API, utils, showToast, formatError } from '/assets/js/config.js';
 
-    let cursor = '';
-    let cache = []; // flat rows for export
+    const YEAR = new Date().getFullYear();
+    document.getElementById('year').textContent = YEAR;
 
-    function rowTotal(v){
-      if(!v || !Array.isArray(v.rows)) return 0;
-      return v.rows.reduce((s,r)=>s + (+r.tarif||0)*(+r.hari||0), 0);
+    const state = {
+      all: [],
+      filtered: [],
+      page: 1,
+      perPage: 20,
+      loading: false,
+      lastCursor: null,
+      cursorStack: [],
+      rawKeys: []
+    };
+
+    const tableBody = document.getElementById('tableBody');
+    const tableWrap = document.getElementById('tableWrap');
+    const tableSkeleton = document.getElementById('tableSkeleton');
+    const emptyState = document.getElementById('emptyState');
+    const totalInfo = document.getElementById('totalInfo');
+    const pageInfo = document.getElementById('pageInfo');
+    const cursorInfo = document.getElementById('cursorInfo');
+
+    const filterControls = {
+      start: document.getElementById('filterStart'),
+      end: document.getElementById('filterEnd'),
+      rumah: document.getElementById('filterRumah'),
+      search: document.getElementById('filterSearch')
+    };
+
+    async function fetchAll() {
+      if (state.loading) return;
+      state.loading = true;
+      state.rawKeys = [];
+      tableSkeleton.classList.remove('hidden');
+      tableWrap.classList.add('hidden');
+      emptyState.classList.add('hidden');
+      totalInfo.textContent = 'Memuat data...';
+      let cursor = '';
+      let safety = 0;
+      try {
+        do {
+          const res = await API.list('ut:snap:', cursor, 100);
+          state.rawKeys.push(...(res.keys || []));
+          cursor = res.cursor || '';
+          safety += 1;
+          if (res.list_complete || !cursor || safety > 20) break;
+        } while (true);
+        await enrichRecords();
+        applyFilter();
+        showToast('Data rekap diperbarui', 'success');
+      } catch (err) {
+        showToast(formatError(err), 'error');
+        tableSkeleton.classList.add('hidden');
+      } finally {
+        state.loading = false;
+      }
     }
 
-    async function loadPage(){
-      const { ok, keys, cursor: c, list_complete } = await API.list('ut:snap:', cursor);
-      $('#tbody').innerHTML = '';
-      cache = [];
-      for(const k of (keys||[])){
-        // optional client-side filter by rumah
-        const rumahQ = $('#qRumah').value.trim().toLowerCase();
-        const periode = (()=>{
-          const parts = (k.name||'').split(':');
-          return parts[2] && parts[3] ? `${parts[2]}→${parts[3]}` : '—';
-        })();
-        const rumah = (()=>{
-          const parts = (k.name||'').split(':');
-          return parts[4] || '';
-        })();
-        if(rumahQ && !String(rumah).toLowerCase().includes(rumahQ)) continue;
+    async function enrichRecords() {
+      const records = [];
+      const needFetch = [];
+      state.rawKeys.forEach((entry) => {
+        const { name, metadata = {} } = entry;
+        const parsed = utils.parseSnapshotKey(name);
+        const record = {
+          key: name,
+          start: metadata.start || parsed.start || '',
+          end: metadata.end || parsed.end || '',
+          rumah: metadata.rumah || parsed.rumah || '',
+          updatedAt: metadata.updatedAt || '',
+          total: metadata.total ?? metadata.totalUpah ?? null,
+          totalDays: metadata.totalDays ?? null,
+          meta: metadata
+        };
+        if (record.total == null || record.totalDays == null) {
+          needFetch.push(record);
+        }
+        records.push(record);
+      });
 
-        // Load detail to calc totals
-        let total = 0, value = null;
-        try {
-          const res = await API.get(k.name);
-          value = res.value || null;
-          total = rowTotal(value);
-        } catch(e){ total = 0; }
+      if (needFetch.length) {
+        for (const item of needFetch) {
+          try {
+            const res = await API.get(item.key);
+            const rows = res?.value?.rows || [];
+            item.total = utils.sumRows(rows);
+            item.totalDays = utils.sumDays(rows);
+            item.start = res?.value?.start || item.start;
+            item.end = res?.value?.end || item.end;
+            item.rumah = res?.value?.rumah || item.rumah;
+            item.updatedAt = res?.meta?.updatedAt || item.updatedAt;
+          } catch (err) {
+            console.error('gagal load detail', item.key, err);
+            item.total = item.total ?? 0;
+            item.totalDays = item.totalDays ?? 0;
+          }
+        }
+      }
+      state.all = records.sort((a, b) => {
+        const dateA = new Date(a.updatedAt || 0).getTime();
+        const dateB = new Date(b.updatedAt || 0).getTime();
+        return dateB - dateA;
+      });
+    }
 
-        const updated = (k.metadata && k.metadata.updatedAt) ? new Date(k.metadata.updatedAt).toLocaleString() : '—';
+    function applyFilter() {
+      const startVal = filterControls.start.value;
+      const endVal = filterControls.end.value;
+      const rumahVal = filterControls.rumah.value.trim().toLowerCase();
+      const searchVal = filterControls.search.value.trim().toLowerCase();
+
+      state.filtered = state.all.filter((item) => {
+        if (startVal && (!item.start || item.start < startVal)) return false;
+        if (endVal && (!item.end || item.end > endVal)) return false;
+        if (rumahVal && !String(item.rumah || '').toLowerCase().includes(rumahVal)) return false;
+        if (searchVal) {
+          const haystack = [item.key, item.rumah, item.start, item.end].join(' ').toLowerCase();
+          if (!haystack.includes(searchVal)) return false;
+        }
+        return true;
+      });
+      state.page = 1;
+      render();
+    }
+
+    function paginate() {
+      const startIndex = (state.page - 1) * state.perPage;
+      return state.filtered.slice(startIndex, startIndex + state.perPage);
+    }
+
+    function render() {
+      const rows = paginate();
+      tableBody.innerHTML = '';
+      if (!state.filtered.length) {
+        tableSkeleton.classList.add('hidden');
+        tableWrap.classList.add('hidden');
+        emptyState.classList.remove('hidden');
+        totalInfo.textContent = '0 snapshot';
+        pageInfo.textContent = 'Halaman 0';
+        cursorInfo.textContent = '';
+        renderSummaries([]);
+        return;
+      }
+      tableSkeleton.classList.add('hidden');
+      tableWrap.classList.remove('hidden');
+      emptyState.classList.add('hidden');
+
+      rows.forEach((item) => {
+        const periode = item.start && item.end ? `${item.start} – ${item.end}` : '—';
+        const updated = item.updatedAt ? new Date(item.updatedAt).toLocaleString('id-ID') : '—';
         const tr = document.createElement('tr');
+        tr.className = 'transition hover:bg-slate-50';
         tr.innerHTML = `
-          <td class="py-2 pr-3">${periode}</td>
-          <td class="py-2 pr-3">${rumah||'—'}</td>
-          <td class="py-2 pr-3 text-right">${utils.rupiah(total)}</td>
-          <td class="py-2 pr-3">${updated}</td>
-          <td class="py-2 pr-3">
-            <a class="px-2 py-1 rounded border" href="/form.html?key=${encodeURIComponent(k.name)}">Buka</a>
-            <button data-key="${k.name}" class="btnDel px-2 py-1 rounded border border-red-300 text-red-600">Hapus</button>
+          <td class="py-3 pr-4 align-top">
+            <div class="font-medium text-slate-800">${periode}</div>
+            <div class="text-xs text-slate-400">${item.key}</div>
+          </td>
+          <td class="py-3 pr-4 align-top text-slate-700">${item.rumah || '—'}</td>
+          <td class="py-3 pr-4 align-top text-right font-medium text-slate-800">${utils.formatRupiah(item.total || 0)}</td>
+          <td class="py-3 pr-4 align-top text-right text-slate-600">${utils.formatNumber(item.totalDays || 0)}</td>
+          <td class="py-3 pr-4 align-top text-slate-600">${updated}</td>
+          <td class="py-3 pl-4 text-right">
+            <div class="flex justify-end gap-2">
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="/form.html?key=${encodeURIComponent(item.key)}">Buka</a>
+              <button class="btnDelete rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-key="${item.key}">Hapus</button>
+            </div>
           </td>
         `;
-        $('#tbody').appendChild(tr);
+        tableBody.appendChild(tr);
+      });
 
-        // push to export cache
-        cache.push({
-          Key: k.name,
-          Periode: periode.replace('→','->'),
-          Rumah: rumah,
-          Total: total,
-          UpdatedAt: (k.metadata && k.metadata.updatedAt) || ''
-        });
-      }
-
-      // summary
-      const sum = cache.reduce((s,r)=>s + (+r.Total||0), 0);
-      $('#sumTotal').textContent = utils.rupiah(sum);
-      $('#sumCount').textContent = String(cache.length);
-      $('#cursorInfo').textContent = list_complete ? 'last page' : (c ? `cursor: ${c.slice(0,8)}...` : '');
-      window._nextC = c || '';
+      const totalPages = Math.max(1, Math.ceil(state.filtered.length / state.perPage));
+      pageInfo.textContent = `Halaman ${state.page} dari ${totalPages}`;
+      totalInfo.textContent = `${state.filtered.length} snapshot`;
+      document.getElementById('btnPrev').disabled = state.page <= 1;
+      document.getElementById('btnNext').disabled = state.page >= totalPages;
+      cursorInfo.textContent = `${rows.length} baris ditampilkan`;
+      renderSummaries(state.filtered);
     }
 
-    document.getElementById('prev').addEventListener('click', ()=>toast('Cursor backward tidak disimpan (demo).'));
-    document.getElementById('next').addEventListener('click', ()=>{ cursor = window._nextC || ''; loadPage(); });
-    document.getElementById('btnExport').addEventListener('click', ()=>{
-      if(!cache.length){ toast('Tidak ada data.'); return; }
-      utils.toXLSX('rekap_upah.xlsx', { 'Rekap': cache });
-    });
-    document.getElementById('qRumah').addEventListener('input', ()=>loadPage());
+    function renderSummaries(records) {
+      const byRumah = new Map();
+      const byHari = new Map();
+      records.forEach((item) => {
+        const rumahKey = item.rumah || 'Tanpa label';
+        byRumah.set(rumahKey, (byRumah.get(rumahKey) || 0) + (item.total || 0));
+        const hariKey = item.start || 'Tanpa tanggal';
+        byHari.set(hariKey, (byHari.get(hariKey) || 0) + (item.total || 0));
+      });
 
-    document.addEventListener('click', async (e)=>{
-      if(e.target.matches('.btnDel')){
-        const key = e.target.getAttribute('data-key');
-        if(confirm('Hapus data ini?')){
+      const rumahList = Array.from(byRumah.entries()).sort((a, b) => b[1] - a[1]).map(([rumah, total]) => `<li class="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2"><span>${rumah}</span><span class="font-semibold">${utils.formatRupiah(total)}</span></li>`);
+      const hariList = Array.from(byHari.entries()).sort((a, b) => a[0].localeCompare(b[0])).map(([hari, total]) => `<li class="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2"><span>${hari}</span><span class="font-semibold">${utils.formatRupiah(total)}</span></li>`);
+
+      document.getElementById('summaryRumah').innerHTML = rumahList.length ? rumahList.join('') : '<li class="rounded-xl border border-dashed border-slate-200 px-3 py-2 text-xs text-slate-400">Tidak ada data</li>';
+      document.getElementById('summaryHari').innerHTML = hariList.length ? hariList.join('') : '<li class="rounded-xl border border-dashed border-slate-200 px-3 py-2 text-xs text-slate-400">Tidak ada data</li>';
+    }
+
+    document.getElementById('btnPrev').addEventListener('click', () => {
+      if (state.page <= 1) return;
+      state.page -= 1;
+      render();
+    });
+
+    document.getElementById('btnNext').addEventListener('click', () => {
+      const totalPages = Math.max(1, Math.ceil(state.filtered.length / state.perPage));
+      if (state.page >= totalPages) return;
+      state.page += 1;
+      render();
+    });
+
+    document.getElementById('btnReset').addEventListener('click', () => {
+      filterControls.start.value = '';
+      filterControls.end.value = '';
+      filterControls.rumah.value = '';
+      filterControls.search.value = '';
+      applyFilter();
+    });
+
+    Object.values(filterControls).forEach((input) => {
+      input.addEventListener('input', utils.debounce(applyFilter, 200));
+    });
+
+    document.addEventListener('click', async (event) => {
+      if (event.target.matches('.btnDelete')) {
+        const key = event.target.getAttribute('data-key');
+        if (!window.confirm('Hapus snapshot ini?')) return;
+        try {
           await API.del(key);
-          toast('Dihapus');
-          loadPage();
+          showToast('Snapshot dihapus', 'success');
+          state.rawKeys = state.rawKeys.filter((entry) => entry.name !== key);
+          state.all = state.all.filter((entry) => entry.key !== key);
+          applyFilter();
+        } catch (err) {
+          showToast(formatError(err), 'error');
         }
       }
     });
 
-    loadPage().catch(err=>toast(err.message));
+    document.getElementById('btnExportXLSX').addEventListener('click', () => {
+      if (!state.filtered.length) {
+        showToast('Tidak ada data untuk diekspor', 'warning');
+        return;
+      }
+      const rows = state.filtered.map((item, idx) => ({
+        No: idx + 1,
+        Key: item.key,
+        Periode: `${item.start} s/d ${item.end}`,
+        Rumah: item.rumah,
+        TotalUpah: item.total,
+        TotalHari: item.totalDays,
+        UpdatedAt: item.updatedAt
+      }));
+      const rumahSheet = [];
+      const rumahAcc = new Map();
+      state.filtered.forEach((item) => {
+        const key = item.rumah || 'Tanpa label';
+        rumahAcc.set(key, (rumahAcc.get(key) || 0) + (item.total || 0));
+      });
+      rumahAcc.forEach((total, rumah) => {
+        rumahSheet.push({ Rumah: rumah, TotalUpah: total });
+      });
+      const hariAcc = new Map();
+      state.filtered.forEach((item) => {
+        const key = item.start || 'Tanpa tanggal';
+        hariAcc.set(key, (hariAcc.get(key) || 0) + (item.total || 0));
+      });
+      const hariSheet = [];
+      hariAcc.forEach((total, hari) => {
+        hariSheet.push({ PeriodeMulai: hari, TotalUpah: total });
+      });
+      utils.toXLSX('rekap_upah.xlsx', {
+        Snapshot: rows,
+        'Total per Rumah': rumahSheet,
+        'Total per Hari': hariSheet
+      });
+      showToast('File XLSX dibuat', 'success');
+    });
+
+    document.getElementById('btnExportCSV').addEventListener('click', () => {
+      if (!state.filtered.length) {
+        showToast('Tidak ada data untuk diekspor', 'warning');
+        return;
+      }
+      const rows = state.filtered.map((item, idx) => ({
+        No: idx + 1,
+        Key: item.key,
+        Periode: `${item.start} s/d ${item.end}`,
+        Rumah: item.rumah,
+        TotalUpah: item.total,
+        TotalHari: item.totalDays,
+        UpdatedAt: item.updatedAt
+      }));
+      utils.toCSV('rekap_upah.csv', rows);
+      showToast('File CSV dibuat', 'success');
+    });
+
+    fetchAll();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the three static pages with a consistent Tailwind layout, toast styling, and an orange "Form Baru" flow
- add a shared client module for Cloudflare KV access plus CSV/XLSX helpers, autosave debounce, and CSV import/export wiring
- harden the Cloudflare Functions endpoints with validation, metadata support, pagination options, and document the UPAH_KV binding steps

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68e371adb67883339a11f0e8229704a8