### PR TITLE
Refactor to centralize upah defaults and helpers

### DIFF
--- a/assets/js/upah-core.js
+++ b/assets/js/upah-core.js
@@ -1,0 +1,492 @@
+import { API, utils, showToast, formatError } from './config.js';
+
+export const STORAGE_ROOT_KEY = 'upahTukang';
+
+// ===== Defaults =====
+export const defaultClassRates = {
+  mandor: { key: 'mandor', label: 'Mandor', rate: 150000 },
+  tukang: { key: 'tukang', label: 'Tukang', rate: 120000 },
+  pekerja: { key: 'pekerja', label: 'Pekerja', rate: 100000 }
+};
+
+export const defaultRumahList = [
+  { id: 'blok-a-01', label: 'Blok A-01' },
+  { id: 'blok-a-02', label: 'Blok A-02' },
+  { id: 'blok-b-01', label: 'Blok B-01' }
+];
+
+export const groupList = [
+  { key: 'mandor', label: 'Mandor' },
+  { key: 'tukang', label: 'Tukang' },
+  { key: 'pekerja', label: 'Pekerja Harian' }
+];
+
+export const dayKeys = ['hari1', 'hari2', 'hari3', 'hari4', 'hari5', 'hari6', 'hari7'];
+
+export const displayDayOrder = dayKeys.map((key, index) => ({ key, label: `Hari ${index + 1}` }));
+
+export const defaultRows = [
+  { nama: '', tarif: 0, hari: 0 }
+];
+
+// ===== Helpers =====
+function deepClone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+export function cloneDefaultRows() {
+  return deepClone(defaultRows);
+}
+
+export function cloneDefaultRates() {
+  return deepClone(defaultClassRates);
+}
+
+export function cloneDefaultRumah() {
+  return deepClone(defaultRumahList);
+}
+
+export function readStorageRoot() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_ROOT_KEY);
+    if (!raw) {
+      return { items: {}, lastKey: null };
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error('Root storage invalid');
+    }
+    return {
+      items: parsed.items && typeof parsed.items === 'object' ? parsed.items : {},
+      lastKey: parsed.lastKey || null
+    };
+  } catch (err) {
+    console.warn('readStorageRoot fallback', err);
+    return { items: {}, lastKey: null };
+  }
+}
+
+export function persistStorageRoot(root) {
+  const safe = {
+    items: root.items || {},
+    lastKey: root.lastKey || null
+  };
+  window.localStorage.setItem(STORAGE_ROOT_KEY, JSON.stringify(safe));
+}
+
+export function createDefaultItem(overrides = {}) {
+  return {
+    key: '',
+    periodStart: '',
+    periodEnd: '',
+    rumah: '',
+    classRates: cloneDefaultRates(),
+    rumahList: cloneDefaultRumah(),
+    allowance: { threshold: 0, amount: 0 },
+    rows: cloneDefaultRows(),
+    meta: {},
+    ...overrides
+  };
+}
+
+// ===== API client =====
+let apiClientInstance = null;
+
+export function ensureApiClient() {
+  if (!apiClientInstance) {
+    apiClientInstance = {
+      async saveData(key, value, meta = {}) {
+        return API.set(key, value, meta);
+      },
+      async loadData(key) {
+        return API.get(key);
+      },
+      async deleteData(key) {
+        return API.del(key);
+      },
+      async list(prefix, cursor = '', limit = 50) {
+        return API.list(prefix, cursor, limit);
+      }
+    };
+  }
+  return apiClientInstance;
+}
+
+// ===== Period helpers =====
+function resolveEndDate(start) {
+  if (!start) return '';
+  const end = utils.plusDaysISO(start, 6);
+  return end || '';
+}
+
+export function updatePeriod(ctx) {
+  if (!ctx) return;
+  const { state, dom } = ctx;
+  if (dom?.periodStart) {
+    const startVal = dom.periodStart.value;
+    const endVal = resolveEndDate(startVal);
+    if (dom.periodEnd) {
+      dom.periodEnd.value = endVal;
+    }
+    state.periodStart = startVal || '';
+    state.periodEnd = endVal || '';
+  }
+}
+
+export function syncPeriodInputs(ctx) {
+  if (!ctx) return;
+  const { state, dom } = ctx;
+  if (dom?.periodStart) {
+    dom.periodStart.value = state.periodStart || '';
+  }
+  if (dom?.periodEnd) {
+    dom.periodEnd.value = state.periodEnd || '';
+  }
+}
+
+// ===== UI/bootstrap hooks =====
+function ensureRows(state) {
+  if (!Array.isArray(state.rows) || !state.rows.length) {
+    state.rows = cloneDefaultRows();
+  }
+}
+
+function computeSummary(rows = []) {
+  const totalRows = rows.length;
+  const totalDays = utils.sumDays(rows);
+  const totalAmount = utils.sumRows(rows);
+  return { totalRows, totalDays, totalAmount };
+}
+
+export function rerender(ctx) {
+  if (!ctx) return;
+  const { state, dom } = ctx;
+  ensureRows(state);
+  if (dom?.tbody) {
+    dom.tbody.innerHTML = '';
+    state.rows.forEach((row, index) => {
+      const isLocked = state.rows.length === 1;
+      const tr = document.createElement('tr');
+      tr.dataset.index = String(index);
+      tr.className = 'transition hover:bg-slate-50';
+      const total = (Number(row.tarif) || 0) * (Number(row.hari) || 0);
+      tr.innerHTML = `
+        <td class="py-2 pr-3">
+          <input class="nm w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" value="${row.nama || ''}" placeholder="Nama Tukang">
+        </td>
+        <td class="py-2 pr-3">
+          <input class="tarif w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" type="number" min="0" step="1000" value="${row.tarif ?? 0}" aria-label="Tarif per hari">
+        </td>
+        <td class="py-2 pr-3">
+          <input class="hari w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" type="number" min="0" max="7" value="${row.hari ?? 0}" aria-label="Jumlah hari kerja">
+        </td>
+        <td class="py-2 pr-3 text-right font-medium text-slate-800">${utils.formatRupiah(total)}</td>
+        <td class="py-2 pr-3 text-right">
+          <button class="btnDelRow rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" ${isLocked ? 'disabled' : ''}>Hapus</button>
+        </td>
+      `;
+      if (isLocked) {
+        const btn = tr.querySelector('.btnDelRow');
+        if (btn) {
+          btn.classList.add('opacity-40', 'cursor-not-allowed');
+        }
+      }
+      dom.tbody.appendChild(tr);
+    });
+  }
+  const summary = computeSummary(state.rows);
+  if (dom?.totalRows) {
+    dom.totalRows.textContent = utils.formatNumber(summary.totalRows);
+  }
+  if (dom?.totalDays) {
+    dom.totalDays.textContent = utils.formatNumber(summary.totalDays);
+  }
+  if (dom?.totalAmount) {
+    dom.totalAmount.textContent = utils.formatRupiah(summary.totalAmount);
+  }
+}
+
+export function bootRatesUI(ctx) {
+  if (!ctx?.state) return;
+  if (!ctx.state.classRates) {
+    ctx.state.classRates = cloneDefaultRates();
+  }
+}
+
+export function renderRumah(ctx) {
+  if (!ctx) return;
+  const { state, dom } = ctx;
+  if (dom?.rumahInput) {
+    dom.rumahInput.value = state.rumah || '';
+  }
+}
+
+export function bootBerasUI(ctx) {
+  if (!ctx?.state) return;
+  if (!ctx.state.allowance) {
+    ctx.state.allowance = { threshold: 0, amount: 0 };
+  }
+}
+
+export function updateBerasRule(ctx, overrides = {}) {
+  if (!ctx?.state) return;
+  ctx.state.allowance = {
+    threshold: overrides.threshold ?? ctx.state.allowance?.threshold ?? 0,
+    amount: overrides.amount ?? ctx.state.allowance?.amount ?? 0
+  };
+}
+
+export function clearRumah(ctx) {
+  if (!ctx) return;
+  ctx.state.rumah = '';
+  renderRumah(ctx);
+}
+
+export function addRumah(ctx, rumahLabel) {
+  if (!ctx) return;
+  if (typeof rumahLabel !== 'string' || !rumahLabel.trim()) return;
+  const label = rumahLabel.trim();
+  const exists = ctx.state.rumahList?.some?.((item) => item?.label === label);
+  if (!exists) {
+    ctx.state.rumahList = Array.isArray(ctx.state.rumahList) ? ctx.state.rumahList.slice() : [];
+    ctx.state.rumahList.push({ id: label.toLowerCase().replace(/\s+/g, '-'), label });
+  }
+  ctx.state.rumah = label;
+  renderRumah(ctx);
+}
+
+export function addWorker(ctx, overrides = {}) {
+  if (!ctx?.state) return;
+  const row = {
+    nama: '',
+    tarif: 0,
+    hari: 0,
+    ...overrides
+  };
+  ctx.state.rows = Array.isArray(ctx.state.rows) ? ctx.state.rows.slice() : [];
+  ctx.state.rows.push(row);
+  rerender(ctx);
+}
+
+export function restoreDefaultRows(ctx) {
+  if (!ctx?.state) return;
+  ctx.state.rows = cloneDefaultRows();
+  rerender(ctx);
+}
+
+// ===== Snapshot & export =====
+function collectRowsFromDOM(ctx) {
+  const rows = [];
+  if (!ctx?.dom?.tbody) return rows;
+  ctx.dom.tbody.querySelectorAll('tr').forEach((tr) => {
+    const nama = tr.querySelector('.nm')?.value?.trim() || '';
+    const tarif = Math.max(0, Number(tr.querySelector('.tarif')?.value) || 0);
+    const hari = Math.max(0, Math.min(7, Number(tr.querySelector('.hari')?.value) || 0));
+    rows.push({ nama, tarif, hari });
+  });
+  return rows;
+}
+
+export function collectRows(ctx) {
+  return collectRowsFromDOM(ctx);
+}
+
+export function applySnapshotDataset(ctx, payload = {}, opts = {}) {
+  if (!ctx?.state) return;
+  const { state } = ctx;
+  state.rows = Array.isArray(payload.rows) && payload.rows.length ? deepClone(payload.rows) : cloneDefaultRows();
+  state.classRates = payload.classRates ? deepClone(payload.classRates) : cloneDefaultRates();
+  state.rumahList = payload.rumahList ? deepClone(payload.rumahList) : cloneDefaultRumah();
+  state.allowance = payload.allowance ? deepClone(payload.allowance) : { threshold: 0, amount: 0 };
+  state.rumah = payload.rumah || '';
+  state.periodStart = payload.periodStart || payload.start || '';
+  state.periodEnd = payload.periodEnd || payload.end || resolveEndDate(state.periodStart);
+  state.key = payload.key || state.key || '';
+  state.meta = payload.meta || state.meta || {};
+  syncPeriodInputs(ctx);
+  renderRumah(ctx);
+  rerender(ctx);
+  if (opts.persist !== false) {
+    const root = readStorageRoot();
+    if (state.key) {
+      root.items[state.key] = {
+        periodStart: state.periodStart,
+        periodEnd: state.periodEnd,
+        rumah: state.rumah,
+        rows: deepClone(state.rows),
+        classRates: deepClone(state.classRates),
+        allowance: deepClone(state.allowance)
+      };
+      root.lastKey = state.key;
+      persistStorageRoot(root);
+    }
+  }
+  if (typeof opts.onApplied === 'function') {
+    opts.onApplied(ctx);
+  }
+}
+
+function preparePayload(ctx, opts = {}) {
+  if (!ctx?.state) return { payload: {}, meta: {} };
+  const rows = collectRowsFromDOM(ctx);
+  const start = ctx.dom?.periodStart?.value || ctx.state.periodStart || '';
+  const end = ctx.dom?.periodEnd?.value || resolveEndDate(start);
+  const rumah = ctx.dom?.rumahInput?.value?.trim() || ctx.state.rumah || '';
+  const payload = {
+    start,
+    end,
+    periodStart: start,
+    periodEnd: end,
+    rumah,
+    rows,
+    classRates: deepClone(ctx.state.classRates || {}),
+    rumahList: deepClone(ctx.state.rumahList || []),
+    allowance: deepClone(ctx.state.allowance || { threshold: 0, amount: 0 })
+  };
+  const total = utils.sumRows(rows);
+  const totalDays = utils.sumDays(rows);
+  const meta = {
+    updatedAt: new Date().toISOString(),
+    start,
+    end,
+    rumah,
+    total,
+    totalDays
+  };
+  if (!ctx.state.key) {
+    const idFromQuery = opts.newId || new URLSearchParams(window.location.search).get('new') || utils.uuid();
+    const rumahSegment = rumah ? rumah.replace(/:/g, '-').trim() : '';
+    if (start && end) {
+      ctx.state.key = `ut:snap:${start}:${end}:${rumahSegment}:${idFromQuery}`;
+    } else {
+      ctx.state.key = `ut:snap:${idFromQuery}`;
+    }
+  }
+  return { payload, meta };
+}
+
+export async function saveAll(ctx, opts = {}) {
+  if (!ctx?.state) return;
+  const notifyFallback = opts.notifyFallback ?? opts.manual ?? false;
+  const { payload, meta } = preparePayload(ctx, opts);
+  if (!payload.start) {
+    throw new Error('Tanggal mulai wajib diisi');
+  }
+  if (!payload.end) {
+    throw new Error('Tanggal selesai wajib diisi');
+  }
+  ctx.state.periodStart = payload.start;
+  ctx.state.periodEnd = payload.end;
+  ctx.state.rumah = payload.rumah;
+  ctx.state.rows = deepClone(payload.rows);
+  const api = ensureApiClient();
+  try {
+    await api.saveData(ctx.state.key, payload, meta);
+  } catch (err) {
+    if (notifyFallback) {
+      try {
+        triggerSnapshotDownload(ctx);
+        showToast('Gagal menyimpan ke server. Snapshot HTML diunduh.', 'warning');
+      } catch (fallbackErr) {
+        console.error('fallback snapshot gagal', fallbackErr);
+      }
+      showToast(formatError(err), 'error');
+    }
+    throw err;
+  }
+  const root = readStorageRoot();
+  root.items[ctx.state.key] = {
+    periodStart: payload.start,
+    periodEnd: payload.end,
+    rumah: payload.rumah,
+    rows: deepClone(payload.rows),
+    classRates: deepClone(payload.classRates),
+    allowance: deepClone(payload.allowance)
+  };
+  root.lastKey = ctx.state.key;
+  persistStorageRoot(root);
+  if (opts.manual) {
+    showToast('Data berhasil disimpan', 'success');
+  }
+  ctx.state.meta = meta;
+  return { payload, meta };
+}
+
+function buildFilename(prefix, ctx) {
+  const start = ctx?.dom?.periodStart?.value || ctx?.state?.periodStart || 'periode';
+  const rumah = ctx?.dom?.rumahInput?.value || ctx?.state?.rumah || 'umum';
+  return `${prefix}_${start}_${rumah}`.replace(/\s+/g, '_');
+}
+
+export function _prepareExportSections(ctx) {
+  const rows = collectRowsFromDOM(ctx);
+  const start = ctx?.dom?.periodStart?.value || ctx?.state?.periodStart || '';
+  const end = ctx?.dom?.periodEnd?.value || ctx?.state?.periodEnd || '';
+  const rumah = ctx?.dom?.rumahInput?.value || ctx?.state?.rumah || '';
+  const summary = {
+    Periode: start && end ? `${start} s/d ${end}` : '',
+    Rumah: rumah,
+    TotalHari: utils.sumDays(rows),
+    TotalUpah: utils.sumRows(rows)
+  };
+  const detailed = rows.map((row, idx) => ({
+    No: idx + 1,
+    Nama: row.nama,
+    Tarif: row.tarif,
+    Hari: row.hari,
+    Total: (Number(row.tarif) || 0) * (Number(row.hari) || 0),
+    Periode: summary.Periode,
+    Rumah: rumah
+  }));
+  return { detailed, summary: [summary] };
+}
+
+export function downloadCSV(ctx) {
+  const { detailed } = _prepareExportSections(ctx);
+  if (!detailed.length) {
+    throw new Error('Tidak ada data untuk diekspor');
+  }
+  const filename = `${buildFilename('upah', ctx)}.csv`;
+  utils.toCSV(filename, detailed);
+}
+
+export function downloadXLSX(ctx) {
+  const { detailed, summary } = _prepareExportSections(ctx);
+  if (!detailed.length) {
+    throw new Error('Tidak ada data untuk diekspor');
+  }
+  const filename = `${buildFilename('upah', ctx)}.xlsx`;
+  utils.toXLSX(filename, {
+    'Upah Mingguan': detailed,
+    Rekap: summary
+  });
+}
+
+export function exportJSON(ctx) {
+  if (!ctx?.state) return;
+  const { payload } = preparePayload(ctx);
+  const filename = `${buildFilename('upah', ctx)}.json`;
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export function triggerSnapshotDownload(ctx) {
+  if (!ctx?.state) return;
+  const { payload } = preparePayload(ctx);
+  const html = `<!doctype html><html lang="id"><head><meta charset="utf-8"><title>Snapshot Upah Tukang</title></head><body><pre>${JSON.stringify(payload, null, 2)}</pre></body></html>`;
+  const filename = `${buildFilename('snapshot', ctx)}.html`;
+  const blob = new Blob([html], { type: 'text/html' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}
+
+export { utils, showToast, formatError };

--- a/form.html
+++ b/form.html
@@ -32,11 +32,11 @@
       <div class="grid gap-4 md:grid-cols-4">
         <label class="flex flex-col gap-1 text-sm">
           <span class="text-xs font-semibold uppercase tracking-wide text-slate-400">Periode (Mulai)</span>
-          <input id="start" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" required>
+          <input id="periodStart" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" required>
         </label>
         <label class="flex flex-col gap-1 text-sm">
           <span class="text-xs font-semibold uppercase tracking-wide text-slate-400">s/d (otomatis +6)</span>
-          <input id="end" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 bg-slate-50" readonly>
+          <input id="periodEnd" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 bg-slate-50" readonly>
         </label>
         <label class="flex flex-col gap-1 text-sm">
           <span class="text-xs font-semibold uppercase tracking-wide text-slate-400">Rumah</span>
@@ -105,248 +105,300 @@
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
-  <script type="module">
-    import { API, utils, showToast, formatError } from '/assets/js/config.js';
+    <script type="module">
+    import {
+      utils,
+      showToast,
+      formatError,
+      readStorageRoot,
+      createDefaultItem,
+      cloneDefaultRows,
+      bootRatesUI,
+      renderRumah,
+      bootBerasUI,
+      rerender,
+      addWorker,
+      restoreDefaultRows,
+      updatePeriod,
+      syncPeriodInputs,
+      applySnapshotDataset,
+      saveAll,
+      downloadCSV,
+      downloadXLSX,
+      ensureApiClient,
+      collectRows
+    } from '/assets/js/upah-core.js';
 
     const YEAR = new Date().getFullYear();
     document.getElementById('year').textContent = YEAR;
 
-    const tbody = document.getElementById('tbody');
+    const ctx = {
+      state: createDefaultItem({ rows: cloneDefaultRows() }),
+      dom: {
+        periodStart: document.getElementById('periodStart'),
+        periodEnd: document.getElementById('periodEnd'),
+        rumahInput: document.getElementById('rumah'),
+        tbody: document.getElementById('tbody'),
+        totalRows: document.getElementById('totalRows'),
+        totalDays: document.getElementById('totalDays'),
+        totalAmount: document.getElementById('totalAmount')
+      }
+    };
+
     const saveState = document.getElementById('saveState');
     const lastSaved = document.getElementById('lastSaved');
     const offlineBadge = document.getElementById('offline');
+    const hiddenKey = document.getElementById('key');
 
-    const state = {
-      key: '',
-      rows: [],
-      dirty: false,
-      saving: false,
-      loaded: false
-    };
+    ctx.state.dirty = false;
+    ctx.state.saving = false;
+    ctx.state.loaded = false;
 
     function setOffline(isOffline) {
       offlineBadge.classList.toggle('hidden', !isOffline);
     }
 
     function markSaving(pending) {
-      state.saving = pending;
+      ctx.state.saving = pending;
       if (pending) {
         saveState.textContent = 'Menyimpan…';
         saveState.className = 'rounded-full bg-amber-100 px-3 py-1 font-medium text-amber-700';
-      } else {
+      } else if (!ctx.state.dirty) {
         saveState.textContent = 'Tersimpan';
         saveState.className = 'rounded-full bg-emerald-100 px-3 py-1 font-medium text-emerald-700';
+      } else {
+        markDirty();
       }
     }
 
     function markDirty() {
-      state.dirty = true;
-      state.saving = false;
+      ctx.state.dirty = true;
+      ctx.state.saving = false;
       saveState.textContent = 'Draft belum tersimpan';
       saveState.className = 'rounded-full bg-slate-200 px-3 py-1 font-medium text-slate-700';
     }
 
-    function ensureRows() {
-      if (!state.rows.length) {
-        state.rows.push({ nama: '', tarif: 0, hari: 0 });
+    function refreshSummaryFromDom() {
+      const rows = collectRows(ctx);
+      if (ctx.dom.totalRows) {
+        ctx.dom.totalRows.textContent = utils.formatNumber(rows.length);
+      }
+      if (ctx.dom.totalDays) {
+        ctx.dom.totalDays.textContent = utils.formatNumber(utils.sumDays(rows));
+      }
+      if (ctx.dom.totalAmount) {
+        ctx.dom.totalAmount.textContent = utils.formatRupiah(utils.sumRows(rows));
       }
     }
 
-    function renderRows() {
-      ensureRows();
-      tbody.innerHTML = '';
-      state.rows.forEach((row, index) => {
-        const isLocked = state.rows.length === 1;
-        const btnClasses = isLocked
-          ? 'btnDelRow rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-400 opacity-40 cursor-not-allowed'
-          : 'btnDelRow rounded-xl border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300';
-        const tr = document.createElement('tr');
-        tr.dataset.index = index;
-        tr.className = 'transition hover:bg-slate-50';
-        tr.innerHTML = `
-          <td class="py-2 pr-3">
-            <input class="nm w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" value="${row.nama || ''}" placeholder="Nama Tukang">
-          </td>
-          <td class="py-2 pr-3">
-            <input class="tarif w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" type="number" min="0" step="1000" value="${row.tarif ?? 0}" aria-label="Tarif per hari">
-          </td>
-          <td class="py-2 pr-3">
-            <input class="hari w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200" type="number" min="0" max="7" value="${row.hari ?? 0}" aria-label="Jumlah hari kerja">
-          </td>
-          <td class="py-2 pr-3 text-right font-medium text-slate-800">${utils.formatRupiah((Number(row.tarif) || 0) * (Number(row.hari) || 0))}</td>
-          <td class="py-2 pr-3 text-right">
-            <button class="${btnClasses}" ${isLocked ? 'disabled' : ''}>Hapus</button>
-          </td>
-        `;
-        tbody.appendChild(tr);
-      });
-      refreshSummary();
+    function syncRowsToState() {
+      ctx.state.rows = collectRows(ctx);
     }
 
-    function refreshSummary() {
-      const totalRows = state.rows.length;
-      const totalDays = utils.sumDays(state.rows);
-      const totalAmount = utils.sumRows(state.rows);
-      document.getElementById('totalRows').textContent = utils.formatNumber(totalRows);
-      document.getElementById('totalDays').textContent = utils.formatNumber(totalDays);
-      document.getElementById('totalAmount').textContent = utils.formatRupiah(totalAmount);
-    }
-
-    function collectForm() {
-      const rows = Array.from(tbody.querySelectorAll('tr')).map((tr) => ({
-        nama: tr.querySelector('.nm').value.trim(),
-        tarif: Math.max(0, Number(tr.querySelector('.tarif').value) || 0),
-        hari: Math.max(0, Math.min(7, Number(tr.querySelector('.hari').value) || 0))
-      }));
-      state.rows = rows;
-      const start = document.getElementById('start').value;
-      const end = document.getElementById('end').value;
-      const rumah = document.getElementById('rumah').value.trim();
-      return { start, end, rumah, rows };
-    }
-
-    function validateForm(payload) {
-      if (!payload.start) {
-        throw new Error('Tanggal mulai wajib diisi');
-      }
-      if (Number.isNaN(new Date(payload.start).getTime())) {
-        throw new Error('Tanggal mulai tidak valid');
-      }
-      if (!payload.end || Number.isNaN(new Date(payload.end).getTime())) {
-        throw new Error('Tanggal selesai tidak valid');
-      }
-      payload.rows.forEach((row, idx) => {
-        if ((Number(row.tarif) || 0) < 0) {
-          throw new Error(`Tarif baris ${idx + 1} tidak boleh negatif`);
-        }
-        if ((Number(row.hari) || 0) < 0) {
-          throw new Error(`Hari kerja baris ${idx + 1} tidak boleh negatif`);
-        }
-      });
-    }
-
-    async function persist(manual = false) {
+    async function handleSave(manual = false, { notifyFallback = manual } = {}) {
       try {
-        const payload = collectForm();
-        validateForm(payload);
-        const total = utils.sumRows(payload.rows);
-        const totalDays = utils.sumDays(payload.rows);
-        if (!state.key) {
-          const idFromQuery = new URLSearchParams(window.location.search).get('new') || utils.uuid();
-          const rumahSegment = payload.rumah ? payload.rumah.replace(/:/g, '-').trim() : '';
-          if (payload.start && payload.end) {
-            state.key = `ut:snap:${payload.start}:${payload.end}:${rumahSegment}:${idFromQuery}`;
-          } else {
-            state.key = `ut:snap:${idFromQuery}`;
-          }
-          document.getElementById('key').value = state.key;
-        }
         markSaving(true);
-        const meta = {
-          updatedAt: new Date().toISOString(),
-          start: payload.start,
-          end: payload.end,
-          rumah: payload.rumah,
-          total,
-          totalDays
-        };
-        await API.set(state.key, payload, meta);
-        state.dirty = false;
+        await saveAll(ctx, { manual, notifyFallback });
+        ctx.state.dirty = false;
         markSaving(false);
+        hiddenKey.value = ctx.state.key || '';
         lastSaved.textContent = `Tersimpan ${new Date().toLocaleTimeString('id-ID')}`;
-        if (manual) {
-          showToast('Data berhasil disimpan', 'success');
-        }
       } catch (err) {
-        if (manual) {
-          showToast(formatError(err), 'error');
-        }
+        markSaving(false);
         markDirty();
+        if (!manual) {
+          console.warn('autosave gagal', err);
+        }
         throw err;
       }
     }
 
     const debouncedSave = utils.debounce(() => {
-      if (!state.loaded) return;
+      if (!ctx.state.loaded) return;
       if (!navigator.onLine) {
         markDirty();
         return;
       }
-      persist(false).catch(() => {});
+      syncRowsToState();
+      handleSave(false, { notifyFallback: false }).catch(() => {});
     }, 800);
 
-    document.addEventListener('input', (event) => {
-      if (event.target.matches('#start')) {
-        const end = utils.plusDaysISO(event.target.value, 6);
-        document.getElementById('end').value = end;
+    async function loadFromKey(key) {
+      const api = ensureApiClient();
+      try {
+        markSaving(true);
+        const res = await api.loadData(key);
+        if (!res || !res.value) {
+          throw new Error('Data tidak ditemukan');
+        }
+        ctx.state.key = key;
+        hiddenKey.value = key;
+        applySnapshotDataset(ctx, { ...res.value, key, meta: res.meta || {} });
+        lastSaved.textContent = res.meta?.updatedAt ? `Terakhir ${new Date(res.meta.updatedAt).toLocaleString('id-ID')}` : '—';
+        ctx.state.dirty = false;
+      } catch (err) {
+        showToast(formatError(err), 'error');
+        restoreDefaultRows(ctx);
+      } finally {
+        markSaving(false);
+        ctx.state.loaded = true;
       }
-      if (event.target.closest('table') || event.target.matches('#start') || event.target.matches('#rumah')) {
+    }
+
+    function tryLoadSnapshotParam(param) {
+      if (!param) return false;
+      try {
+        const decoded = JSON.parse(atob(decodeURIComponent(param)));
+        ctx.state.key = decoded.key || ctx.state.key;
+        if (ctx.state.key) hiddenKey.value = ctx.state.key;
+        applySnapshotDataset(ctx, decoded, { persist: true });
+        ctx.state.loaded = true;
+        lastSaved.textContent = decoded?.meta?.updatedAt ? `Terakhir ${new Date(decoded.meta.updatedAt).toLocaleString('id-ID')}` : 'Snapshot dimuat';
+        return true;
+      } catch (err) {
+        console.warn('gagal decode snapshot', err);
+        showToast('Snapshot tidak valid', 'error');
+        return false;
+      }
+    }
+
+    function tryLoadHistory(histKey) {
+      if (!histKey) return false;
+      const root = readStorageRoot();
+      let entry = null;
+      if (root.items[histKey]) {
+        entry = { key: histKey, value: root.items[histKey] };
+      } else {
+        const found = Object.entries(root.items).find(([, item]) => item.periodStart === histKey || item.periodEnd === histKey);
+        if (found) {
+          entry = { key: found[0], value: found[1] };
+        }
+      }
+      if (!entry) return false;
+      ctx.state.key = entry.key;
+      hiddenKey.value = entry.key;
+      applySnapshotDataset(ctx, { ...entry.value, key: entry.key }, { persist: false });
+      ctx.state.loaded = true;
+      lastSaved.textContent = 'Draft lokal dimuat';
+      return true;
+    }
+
+    async function initFromQuery() {
+      bootRatesUI(ctx);
+      bootBerasUI(ctx);
+      renderRumah(ctx);
+      rerender(ctx);
+
+      const params = new URLSearchParams(window.location.search);
+      const keyParam = params.get('key');
+      const snapshotParam = params.get('snapshot');
+      const histParam = params.get('hist');
+      const startParam = params.get('start');
+      const endParam = params.get('end');
+
+      if (window.__UPAH_DATA__) {
+        applySnapshotDataset(ctx, window.__UPAH_DATA__, { persist: false });
+      }
+
+      if (keyParam) {
+        await loadFromKey(keyParam);
+        return;
+      }
+
+      if (snapshotParam && tryLoadSnapshotParam(snapshotParam)) {
+        return;
+      }
+
+      if (histParam && tryLoadHistory(histParam)) {
+        return;
+      }
+
+      const root = readStorageRoot();
+      if (root.lastKey && root.items[root.lastKey]) {
+        ctx.state.key = root.lastKey;
+        hiddenKey.value = ctx.state.key;
+        applySnapshotDataset(ctx, { ...root.items[root.lastKey], key: ctx.state.key }, { persist: false });
+        ctx.state.loaded = true;
+        lastSaved.textContent = 'Draft lokal dimuat';
+        return;
+      }
+
+      const startValue = startParam || utils.todayISO();
+      const endValue = endParam || utils.plusDaysISO(startValue, 6);
+      ctx.state.periodStart = startValue;
+      ctx.state.periodEnd = endValue;
+      syncPeriodInputs(ctx);
+      renderRumah(ctx);
+      rerender(ctx);
+      ctx.state.loaded = true;
+    }
+
+    document.addEventListener('input', (event) => {
+      if (event.target.matches('#periodStart')) {
+        updatePeriod(ctx);
+        syncPeriodInputs(ctx);
         markDirty();
-        refreshSummary();
+        refreshSummaryFromDom();
+        debouncedSave();
+        return;
+      }
+      if (event.target.matches('#rumah')) {
+        markDirty();
+        refreshSummaryFromDom();
+        debouncedSave();
+        return;
+      }
+      if (event.target.closest('table')) {
+        markDirty();
+        refreshSummaryFromDom();
         debouncedSave();
       }
     });
 
-    tbody.addEventListener('click', (event) => {
+    document.getElementById('tbody').addEventListener('click', (event) => {
       if (event.target.matches('.btnDelRow')) {
         event.preventDefault();
         const tr = event.target.closest('tr');
         const index = Number(tr.dataset.index);
-        if (state.rows.length <= 1) {
+        syncRowsToState();
+        if (ctx.state.rows.length <= 1) {
           showToast('Minimal satu baris data', 'warning');
           return;
         }
-        state.rows.splice(index, 1);
-        renderRows();
+        ctx.state.rows.splice(index, 1);
+        rerender(ctx);
         markDirty();
+        refreshSummaryFromDom();
         debouncedSave();
       }
     });
 
     document.getElementById('btnAddRow').addEventListener('click', () => {
-      state.rows.push({ nama: '', tarif: 0, hari: 0 });
-      renderRows();
+      syncRowsToState();
+      addWorker(ctx);
       markDirty();
+      refreshSummaryFromDom();
       debouncedSave();
     });
 
     document.getElementById('btnClear').addEventListener('click', () => {
       if (!window.confirm('Kosongkan tabel? Data tersimpan tidak dihapus.')) return;
-      state.rows = [{ nama: '', tarif: 0, hari: 0 }];
-      renderRows();
+      restoreDefaultRows(ctx);
       markDirty();
+      refreshSummaryFromDom();
     });
 
-    document.getElementById('btnSave').addEventListener('click', async () => {
-      try {
-        await persist(true);
-      } catch (err) {
-        showToast(formatError(err), 'error');
-      }
+    document.getElementById('btnSave').addEventListener('click', () => {
+      syncRowsToState();
+      handleSave(true, { notifyFallback: true }).catch((err) => {
+        console.error('gagal menyimpan manual', err);
+      });
     });
 
     document.getElementById('btnExportXLSX').addEventListener('click', () => {
       try {
-        const payload = collectForm();
-        const rows = payload.rows.map((row, idx) => ({
-          No: idx + 1,
-          Nama: row.nama,
-          Tarif: row.tarif,
-          Hari: row.hari,
-          Total: (Number(row.tarif) || 0) * (Number(row.hari) || 0),
-          Periode: `${payload.start} s/d ${payload.end}`,
-          Rumah: payload.rumah
-        }));
-        const summary = [{
-          Periode: `${payload.start} s/d ${payload.end}`,
-          Rumah: payload.rumah,
-          TotalHari: utils.sumDays(payload.rows),
-          TotalUpah: utils.sumRows(payload.rows)
-        }];
-        utils.toXLSX(`upah_${payload.start || 'periode'}_${payload.rumah || 'umum'}.xlsx`, {
-          'Upah Mingguan': rows,
-          Rekap: summary
-        });
+        syncRowsToState();
+        downloadXLSX(ctx);
         showToast('Berhasil membuat file XLSX', 'success');
       } catch (err) {
         showToast(formatError(err), 'error');
@@ -355,17 +407,8 @@
 
     document.getElementById('btnExportCSV').addEventListener('click', () => {
       try {
-        const payload = collectForm();
-        const rows = payload.rows.map((row, idx) => ({
-          No: idx + 1,
-          Nama: row.nama,
-          Tarif: row.tarif,
-          Hari: row.hari,
-          Total: (Number(row.tarif) || 0) * (Number(row.hari) || 0),
-          Periode: `${payload.start} s/d ${payload.end}`,
-          Rumah: payload.rumah
-        }));
-        utils.toCSV(`upah_${payload.start || 'periode'}_${payload.rumah || 'umum'}.csv`, rows);
+        syncRowsToState();
+        downloadCSV(ctx);
         showToast('Berhasil membuat file CSV', 'success');
       } catch (err) {
         showToast(formatError(err), 'error');
@@ -383,13 +426,14 @@
           if (!parsed.rows.length) {
             throw new Error('File CSV kosong');
           }
-          state.rows = parsed.rows.map((row) => ({
+          ctx.state.rows = parsed.rows.map((row) => ({
             nama: row.Nama || row.nama || '',
             tarif: Number(row.Tarif ?? row.tarif ?? 0) || 0,
             hari: Number(row.Hari ?? row.hari ?? 0) || 0
           }));
-          renderRows();
+          rerender(ctx);
           markDirty();
+          refreshSummaryFromDom();
           debouncedSave();
           showToast('Data CSV dimuat', 'success');
         } catch (err) {
@@ -403,60 +447,16 @@
 
     window.addEventListener('online', () => {
       setOffline(false);
-      if (state.dirty) {
+      if (ctx.state.dirty) {
         debouncedSave();
       }
     });
     window.addEventListener('offline', () => setOffline(true));
 
-    async function loadFromKey(key) {
-      try {
-        markSaving(true);
-        const res = await API.get(key);
-        if (!res || !res.value) {
-          throw new Error('Data tidak ditemukan');
-        }
-        state.key = key;
-        document.getElementById('key').value = key;
-        document.getElementById('start').value = res.value.start || utils.todayISO();
-        document.getElementById('end').value = res.value.end || utils.plusDaysISO(document.getElementById('start').value, 6);
-        document.getElementById('rumah').value = res.value.rumah || '';
-        state.rows = Array.isArray(res.value.rows) && res.value.rows.length ? res.value.rows : [{ nama: '', tarif: 0, hari: 0 }];
-        renderRows();
-        markSaving(false);
-        lastSaved.textContent = res.meta?.updatedAt ? `Terakhir ${new Date(res.meta.updatedAt).toLocaleString('id-ID')}` : '—';
-        state.loaded = true;
-        state.dirty = false;
-      } catch (err) {
-        markSaving(false);
-        showToast(formatError(err), 'error');
-        state.rows = [{ nama: '', tarif: 0, hari: 0 }];
-        renderRows();
-        state.loaded = true;
-      }
-    }
-
-    function initFromQuery() {
-      const params = new URLSearchParams(window.location.search);
-      const key = params.get('key');
-      const startParam = params.get('start');
-      const endParam = params.get('end');
-      if (key) {
-        loadFromKey(key).then(() => {
-          state.loaded = true;
-        });
-        return;
-      }
-      state.key = '';
-      document.getElementById('start').value = startParam || utils.todayISO();
-      document.getElementById('end').value = endParam || utils.plusDaysISO(document.getElementById('start').value, 6);
-      state.rows = [{ nama: '', tarif: 0, hari: 0 }];
-      renderRows();
-      state.loaded = true;
-    }
-
-    initFromQuery();
+    await initFromQuery();
     setOffline(!navigator.onLine);
+    refreshSummaryFromDom();
   </script>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -94,7 +94,9 @@
 
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { API, utils, showToast, formatError } from '/assets/js/config.js';
+    import { utils, showToast, formatError, ensureApiClient } from '/assets/js/upah-core.js';
+
+    const api = ensureApiClient();
 
     const YEAR = new Date().getFullYear();
     document.getElementById('year').textContent = YEAR;
@@ -155,7 +157,7 @@
         skeleton.classList.remove('hidden');
         emptyState.classList.add('hidden');
         listInfo.textContent = 'Memuat data...';
-        const { keys = [], cursor, list_complete } = await API.list('ut:snap:', state.cursor, 15);
+        const { keys = [], cursor, list_complete } = await api.list('ut:snap:', state.cursor, 15);
         skeleton.classList.add('hidden');
         if (!keys.length && !state.cursor && !cursor) {
           emptyState.classList.remove('hidden');
@@ -199,7 +201,7 @@
         const confirmed = window.confirm('Hapus snapshot ini? Data tidak dapat dikembalikan.');
         if (!confirmed) return;
         try {
-          await API.del(key);
+          await api.deleteData(key);
           showToast('Snapshot dihapus', 'success');
           loadList();
         } catch (err) {

--- a/rekap.html
+++ b/rekap.html
@@ -115,7 +115,9 @@
 
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { API, utils, showToast, formatError } from '/assets/js/config.js';
+    import { utils, showToast, formatError, ensureApiClient } from '/assets/js/upah-core.js';
+
+    const api = ensureApiClient();
 
     const YEAR = new Date().getFullYear();
     document.getElementById('year').textContent = YEAR;
@@ -158,7 +160,7 @@
       let safety = 0;
       try {
         do {
-          const res = await API.list('ut:snap:', cursor, 100);
+          const res = await api.list('ut:snap:', cursor, 100);
           state.rawKeys.push(...(res.keys || []));
           cursor = res.cursor || '';
           safety += 1;
@@ -200,7 +202,7 @@
       if (needFetch.length) {
         for (const item of needFetch) {
           try {
-            const res = await API.get(item.key);
+            const res = await api.loadData(item.key);
             const rows = res?.value?.rows || [];
             item.total = utils.sumRows(rows);
             item.totalDays = utils.sumDays(rows);
@@ -344,7 +346,7 @@
         const key = event.target.getAttribute('data-key');
         if (!window.confirm('Hapus snapshot ini?')) return;
         try {
-          await API.del(key);
+          await api.deleteData(key);
           showToast('Snapshot dihapus', 'success');
           state.rawKeys = state.rawKeys.filter((entry) => entry.name !== key);
           state.all = state.all.filter((entry) => entry.key !== key);


### PR DESCRIPTION
## Summary
- extract shared defaults, helper utilities, and snapshot/export logic into `assets/js/upah-core.js`
- update `form.html` to initialize from the shared module for period syncing, autosave, and exports while loading snapshots consistently
- refactor `index.html` and `rekap.html` to consume the shared API client utilities instead of duplicating KV access logic

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68e3768bb6dc83338a7b99e03d7428cb