### PR TITLE
Refresh form UI and improve snapshot pagination

### DIFF
--- a/form.html
+++ b/form.html
@@ -1,1056 +1,664 @@
 <!doctype html>
 <html lang="id">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<title>Kalkulator Upah — Group + Uang Beras (Mobile Friendly)</title>
-<style>
-  :root { --bg:#0f172a; --card:#0b1220; --text:#e5e7eb; --sub:#94a3b8; --border:#334155; --hi:#0ea5b7; --accent:#10b981; --warn:#f59e0b; }
-  * { box-sizing: border-box; }
-  html, body { height:100%; }
-  body { margin:0; background:var(--bg); color:var(--text);
-         font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, 'Noto Sans', Arial;
-         font-size:10pt; line-height:1.35;}
-  .container { max-width:1280px; margin:0 auto; padding:18px; }
-  h1 { margin:0 0 6px; font-size:21px; }
-  h3 { margin:0 0 6px; font-size:15px; }
-  .sub { color:var(--sub); margin-bottom:12px; }
-  .card { background:var(--card); border:1px solid var(--border); border-radius:14px; padding:12px; margin-bottom:10px; }
-  .row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
-  .stack { display:flex; flex-direction:column; gap:8px; }
-  .btn { padding:7px 12px; border-radius:12px; border:1px solid var(--border); background:var(--card); color:var(--text); cursor:pointer; font-size:0.95em; }
-  .btn.primary { background:var(--hi); border:0; color:#05202c; font-weight:700; }
-  .btn.ghost { background:transparent; border:1px dashed var(--border); }
-  .btn.small { padding:5px 9px; font-size:0.85em; }
-  .btn.block { width:100%; text-align:center; }
-  .input, select, textarea { background:var(--card); border:1px solid var(--border); color:var(--text); padding:8px 10px; border-radius:12px; width:100%; font-size:0.95em; min-height:40px; }
-  select { appearance:none; }
-  .chip { display:inline-flex; align-items:center; gap:6px; padding:6px 10px; border-radius:999px; border:1px solid var(--border); background:var(--card); margin:4px 6px 0 0; font-size:0.95em; }
-  .chip button { background:transparent; border:0; color:var(--sub); cursor:pointer; }
-  table { width:100%; border-collapse:collapse; }
-  th, td { padding:6px; border-bottom:1px dashed var(--border); vertical-align:top; }
-  thead th { background:var(--card); position:sticky; top:0; z-index:2; }
-  .center { text-align:center; }
-  .right { text-align:right; }
-  .sum { font-weight:800; font-size:1.05em; }
-  .muted { color:var(--sub); font-size:10px; }
-  .cellstack { display:flex; flex-direction:column; gap:2px; align-items:flex-end; }
-  .cellstack .cnt { font-size:10px; color:var(--sub); }
-  .badge { display:inline-block; padding:2px 6px; border-radius:999px; border:1px solid var(--border); color:var(--sub); margin-left:8px; font-weight:600; }
-  .group-head td { background:rgba(14,165,183,0.09); border-bottom:1px solid var(--border); font-weight:700; }
-  .group-sub td { background:rgba(14,165,183,0.05); border-top:1px dashed var(--border); font-weight:700; }
-  .scroll-x { overflow-x:auto; -webkit-overflow-scrolling: touch; }
-  /* Floating action bar for mobile */
-  .fabbar { position:fixed; left:0; right:0; bottom:0; z-index:9; padding:8px 8px; backdrop-filter:saturate(120%) blur(4px); }
-.container { padding-bottom: 140px; } 
-@supports (padding: max(0px)) {
-  .container { padding-bottom: max(140px, env(safe-area-inset-bottom)); }
-}
-@media print { .fabbar { visibility: hidden !important; } }
-  .fabbar .card { display:flex; gap:8px; align-items:center; justify-content:space-between; padding:10px; }
-  .pill { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border-radius:999px; background:rgba(16,185,129,0.12); border:1px solid rgba(16,185,129,0.35); color:#a7f3d0; font-weight:700; }
-  .pill .small { font-weight:500; color:#d1fae5; font-size:11px;}
-  /* Card Mode styles */
-  .worker-card { border:1px solid var(--border); border-radius:14px; padding:10px; background:rgba(255,255,255,0.02); margin-bottom:8px; }
-  .card-header { display:flex; gap:8px; align-items:center; justify-content:space-between; }
-  .name { font-weight:800; font-size:1.05em; }
-  .daygrid { display:grid; grid-template-columns: repeat(2, 1fr); gap:8px; }
-  .daygrid .item { display:flex; flex-direction:column; gap:4px; }
-  .kv { display:flex; gap:10px; flex-wrap:wrap; }
-  .kv .row { gap:6px; }
-  .totals { display:flex; flex-wrap:wrap; gap:8px; }
-  .totals .chip { margin:0; }
-  .quickchips { margin-top:6px; }
-  /* Responsive overrides */
-  @media (max-width: 900px) {
-    body { font-size:12pt; }
-    .container { padding:12px; }
-    .btn { min-height:42px; }
-    .input, select, textarea { font-size:16px; min-height:44px; } /* prevent iOS zoom */
-    .daygrid { grid-template-columns: 1fr; }
-    .hide-sm { visibility: hidden !important; }
-  }
-  @media print {
-    .btn, .fabbar { visibility: hidden !important; }
-    .card { break-inside: avoid; }
-    thead th { position: static; }
-  }
-
-  .input.right{ text-align:right; }
-</style>
-
-<style>
-:root {
-  --rowA: rgba(148,163,184,0.06);
-  --rowB: rgba(148,163,184,0.12);
-  --cardA: rgba(255,255,255,0.03);
-  --cardB: rgba(255,255,255,0.06);
-}
-tbody tr.zebra-a td { background: var(--rowA); }
-tbody tr.zebra-b td { background: var(--rowB); }
-.worker-card.zebra-a { background: var(--cardA); }
-.worker-card.zebra-b { background: var(--cardB); }
-@media print {
-  tbody tr.zebra-a td, tbody tr.zebra-b td {
-    -webkit-print-color-adjust: exact; print-color-adjust: exact;
-  }
-}
-</style>
-
-
-
-<style>
-@media print {
-  /* Remove all visual boxes */
-  * { box-shadow: none !important; text-shadow: none !important; }
-  html, body { background: #ffffff !important; color: #000 !important; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-  /* Tables */
-  table, thead, tbody, tfoot, tr, th, td { 
-    background: transparent !important; 
-    border: 0 !important; 
-    outline: 0 !important;
-  }
-  /* Remove zebra/card fills */
-  tbody tr.zebra-a td, tbody tr.zebra-b td,
-  .worker-card.zebra-a, .worker-card.zebra-b,
-  .worker-card, .card, .panel, .section, .container {
-    background: transparent !important; border: 0 !important; outline: 0 !important;
-  }
-  /* Group/Subtotal rows */
-  .group-head td, .group-sub td, .subtotal-row td, .subtotal-row, .group-header, .group-subtotal {
-    background: transparent !important; border: 0 !important; outline: 0 !important;
-  }
-  /* Header rows: no sticky, no background */
-  thead tr, .sticky { position: static !important; background: transparent !important; }
-  /* Horizontal rules */
-  hr { border: 0 !important; height: 0 !important; }
-  /* Inputs/buttons hidden in print unless they hold values to show */
-  button, .btn, .controls, .toolbar, .no-print { visibility: hidden !important; }
-  /* Ensure good spacing (optional, mild) */
-  td, th { padding: 2px 4px !important; }
-}
-</style>
-
-
-<style>
-@media print {
-  /* Flatten any chip/pill/badge-like elements so only text remains */
-  .chip, .badge, .pill, .tag, .lozenge,
-  [class*="chip"], [class*="badge"], [class*="pill"], [class*="tag"], [class*="lozenge"] {
-    background: transparent !important;
-    border: 0 !important;
-    box-shadow: none !important;
-    outline: 0 !important;
-    border-radius: 0 !important;
-    padding: 0 !important;
-  }
-  /* Remove any inner boxes inside table cells/headers */
-  th *, td * {
-    background: transparent !important;
-    border: 0 !important;
-    box-shadow: none !important;
-    outline: 0 !important;
-    border-radius: 0 !important;
-  }
-  /* Inputs/selects rendered as plain text */
-  input, select, textarea {
-    -webkit-appearance: none !important;
-    appearance: none !important;
-    background: transparent !important;
-    border: 0 !important;
-    outline: 0 !important;
-    box-shadow: none !important;
-  }
-}
-</style>
-
-
-<style>
-@media print {
-  /* Force ALL text (and pseudo-elements) to pure black */
-  *, *::before, *::after {
-    color: #000 !important;
-    -webkit-text-fill-color: #000 !important;
-    text-shadow: none !important;
-  }
-  a, a:link, a:visited, a:active {
-    color: #000 !important;
-    text-decoration: none !important;
-  }
-  /* Inputs/selects text black */
-  input, select, textarea {
-    color: #000 !important;
-    -webkit-text-fill-color: #000 !important;
-  }
-  /* SVG text/icons */
-  svg *, svg text, svg tspan {
-    fill: #000 !important;
-    stroke: #000 !important;
-  }
-  /* Prefer light color scheme for print */
-  :root { color-scheme: light !important; }
-}
-</style>
-
-
-<style>
-.topbar{ display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; }
-.topbar h1{ margin:0; }
-.search-box input{
-  padding:8px 10px; border:1px solid var(--line, #e5e7eb); border-radius:10px;
-  font-size:14px; min-width:220px;
-}
-@media (max-width:520px){
-  .search-box input{ min-width:160px; width:100%; }
-}
-@media print { .search-box{ visibility: hidden !important; } }
-</style>
-
-
-<style>
-/* Sticky top search bar */
-.topbar{
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  padding: 8px 10px;
-  background: rgba(255,255,255,0.9);
-  -webkit-backdrop-filter: saturate(120%) blur(4px);
-  backdrop-filter: saturate(120%) blur(4px);
-  border-bottom: 1px solid rgba(0,0,0,0.08);
-}
-@media (prefers-color-scheme: dark){
-  .topbar{ background: rgba(23,23,23,0.9); border-bottom-color: rgba(255,255,255,0.08); }
-}
-@media print { .topbar{ visibility: hidden !important; } }
-</style>
-
-
-<style>
-.collapsible > summary {
-  display:flex; align-items:center; justify-content:space-between; gap:12px;
-  cursor:pointer; list-style:none; user-select:none;
-  margin:0; padding:4px 2px;
-}
-.collapsible > summary::-webkit-details-marker { display:none; }
-.collapsible > summary .sum-title { font-size:16px; font-weight:700; }
-.collapsible > summary::before {
-  content:"▸"; margin-right:8px; font-size:14px; transform-origin:center;
-  transition: transform .2s ease;
-}
-.collapsible[open] > summary::before { content:"▾"; }
-.sum-actions { display:inline-flex; align-items:center; gap:6px; }
-@media print { .collapsible > summary::before { content:""; } }
-</style>
-
-
-<style>
-.main-actions{ margin: 8px 0 10px; }
-</style>
-
-
-<style>
-#pengaturan-actions-row{ margin-top: 8px; }
-</style>
-
-
-<style>
-/* Make only the search sticky, not the whole header */
-.topbar{ position: static !important; background: transparent; border-bottom: none; }
-.search-sticky{
-  position: sticky; top: 0; z-index: 10;
-  background: rgba(255,255,255,0.9);
-  -webkit-backdrop-filter: saturate(120%) blur(4px);
-  backdrop-filter: saturate(120%) blur(4px);
-  border-bottom: 1px solid rgba(0,0,0,0.08);
-  padding: 6px 10px;
-}
-@media (prefers-color-scheme: dark){
-  .search-sticky{ background: rgba(23,23,23,0.9); border-bottom-color: rgba(255,255,255,0.08); }
-}
-@media print{ .search-sticky{ visibility: hidden !important; } }
-</style>
-
-
-<style>
-/* Sticky by default (desktop/tablet) */
-.search-sticky{
-  position: sticky; top: 0; z-index: 20;
-  background: rgba(255,255,255,0.9);
-  -webkit-backdrop-filter: saturate(120%) blur(4px);
-  backdrop-filter: saturate(120%) blur(4px);
-  border-bottom: 1px solid rgba(0,0,0,0.08);
-  padding: 6px 10px;
-}
-/* Floating on small screens */
-@media (max-width: 768px){
-  .search-sticky{
-    position: fixed; left: auto; right: 12px; top: 10px; z-index: 50;
-    border: 1px solid rgba(0,0,0,0.12);
-    border-radius: 10px;
-    box-shadow: 0 8px 24px rgba(0,0,0,0.12);
-    padding: 8px 10px;
-    width: min(86vw, 360px);
-    background: rgba(255,255,255,0.98);
-  }
-  .container{ padding-top: 72px; } /* Prevent overlap with top content */
-}
-@media (prefers-color-scheme: dark){
-  .search-sticky{ background: rgba(23,23,23,0.9); border-bottom-color: rgba(255,255,255,0.08); }
-  @media (max-width: 768px){
-    .search-sticky{ background: rgba(23,23,23,0.98); border-color: rgba(255,255,255,0.12); }
-  }
-}
-@media print{ .search-sticky{ visibility: hidden !important; } }
-</style>
-
-
-<style>
-:root { --day-zebra: rgba(0,0,0,0.03); }
-@media (prefers-color-scheme: dark){ :root { --day-zebra: rgba(255,255,255,0.04); } }
-#tbl thead th:nth-child(6), #tbl tbody td:nth-child(6),
-#tbl thead th:nth-child(8), #tbl tbody td:nth-child(8),
-#tbl thead th:nth-child(10), #tbl tbody td:nth-child(10),
-#tbl thead th:nth-child(12), #tbl tbody td:nth-child(12) { background: var(--day-zebra); }
-@media print{
-  #tbl thead th, #tbl tbody td { background: transparent !important; }
-}
-</style>
-
-
-<style>
-/* Stronger zebra + apply to card mode */
-/* Slightly stronger contrast */
-:root { --day-zebra: rgba(0,0,0,0.06); }
-@media (prefers-color-scheme: dark){ :root { --day-zebra: rgba(255,255,255,0.10); } }
-/* Cards: zebra by day item (including the day title label) */
-.daygrid .item:nth-child(odd){
-  background: var(--day-zebra);
-  border-radius: 10px;
-  padding: 8px;
-}
-@media print{
-  .daygrid .item{ background: transparent !important; }
-}
-</style>
-
-
-<style>
-/* Enforce zebra for CARD mode (including the day title block) */
-:root { --day-zebra: rgba(0,0,0,0.10); }
-@media (prefers-color-scheme: dark){ :root { --day-zebra: rgba(255,255,255,0.16); } }
-/* Use :nth-of-type to avoid counting text nodes; make it stronger with !important */
-.daygrid > .item:nth-of-type(odd){
-  background-color: var(--day-zebra) !important;
-}
-@media print{ .daygrid > .item{ background: transparent !important; } }
-</style>
-
-
-<style>
-/* Force zebra in CARD mode regardless of inner wrapper structure */
-:root { --day-zebra: rgba(0,0,0,0.10); }
-@media (prefers-color-scheme: dark){ :root { --day-zebra: rgba(255,255,255,0.16); } }
-#cardsWrap .daygrid > *:nth-of-type(odd){
-  background-color: var(--day-zebra) !important;
-}
-#cardsWrap .daygrid > *:nth-of-type(odd) .daytitle{
-  background-color: transparent !important;
-}
-@media print{
-  #cardsWrap .daygrid > *{ background: transparent !important; }
-}
-</style>
-
-
-<style>
-.fabbar .search-box{ margin-top: 6px; }
-.fabbar .search-box input{ min-width: 220px; }
-@media (max-width: 560px){
-  .fabbar .search-box input{ width: 100%; }
-}
-</style>
-
-
-<style>
-@media (max-width: 768px){
-  #tableWrap{ overflow-x: auto; -webkit-overflow-scrolling: touch; }
-  #tableWrap table{ min-width: 900px; }
-}
-</style>
-
-
-<style>
-/* Force the app title to white on-screen */
-.topbar h1, .header h1, h1.app-title, h1#appTitle, h1 {
-  color: #ffffff !important;
-}
-/* Keep print output black for clean PDF */
-@media print{
-  .topbar h1, .header h1, h1.app-title, h1#appTitle, h1 {
-    color: #000000 !important;
-  }
-}
-</style>
-
-
-<style>
-/* ===== Layout polish ===== */
-#secOptions { margin-top: 8px; }
-#secOptions .row { gap: 10px; }
-#secOptions .row > div { flex: 1 1 200px; min-width: 180px; }
-#secOptions input.input, #secOptions select.input { width: 100% !important; }
-/* Grouped cards spacing */
-#secOptions > .card { margin-top: 10px; }
-#pengaturan-actions-row { gap: 8px; flex-wrap: wrap; }
-#pengaturan-actions-row .btn { min-width: max(140px, 18ch); }
-/* Headings and chips spacing */
-.card h3 { margin: 0 0 8px !important; }
-.chip { line-height: 1.2; }
-/* Table wrapper refine */
-#tableWrap > div { border-radius: 12px; overflow: hidden; }
-/* Make main action row nicely spaced */
-.main-actions .btn { min-height: 40px; }
-</style>
-
-
-<style>
-.pengaturan-card { border-radius: 12px; }
-.pengaturan-card .subcard { background: transparent; box-shadow: none; border: 0; padding: 0; margin-top: 8px; }
-.pengaturan-card .subcard + .subcard { margin-top: 14px; border-top: 1px dashed rgba(0,0,0,.15); padding-top: 10px; }
-@media (prefers-color-scheme: dark){
-  .pengaturan-card .subcard + .subcard { border-top-color: rgba(255,255,255,.2); }
-}
-</style>
-
-
-<style>
-/* ==== Pengaturan layout tidy (scoped) ==== */
-.pengaturan-card{
-  border-radius: 12px;
-  padding: 12px 14px;
-  border: 1px solid rgba(0,0,0,.08);
-  box-shadow: 0 1px 6px rgba(0,0,0,.05);
-}
-@media (prefers-color-scheme: dark){
-  .pengaturan-card{ border-color: rgba(255,255,255,.12); box-shadow: 0 1px 6px rgba(0,0,0,.35); }
-}
-.pengaturan-card h3{
-  margin: 0 0 10px !important;
-  font-size: 14px;
-  font-weight: 600;
-  line-height: 1.3;
-}
-.pengaturan-card .subcard{
-  background: transparent;
-  border: 0;
-  box-shadow: none;
-  padding: 0;
-  margin-top: 8px;
-}
-.pengaturan-card .subcard + .subcard{
-  margin-top: 14px;
-  border-top: 1px dashed rgba(0,0,0,.14);
-  padding-top: 10px;
-}
-@media (prefers-color-scheme: dark){
-  .pengaturan-card .subcard + .subcard{ border-top-color: rgba(255,255,255,.24); }
-}
-
-/* Form rows inside Pengaturan: aligned labels & inputs */
-#secOptions .row{ display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-#secOptions .row label.muted{ flex: 0 0 180px; max-width: 180px; }
-#secOptions .row input.input, #secOptions .row select.input, #secOptions .row .input{
-  flex: 1 1 260px; min-width: 220px;
-}
-/* Chips list (Master Rumah) */
-#secOptions .chips{ display: flex; flex-wrap: wrap; gap: 6px; padding-top: 2px; }
-#secOptions .chip{ border-radius: 999px; padding: 4px 8px; display: inline-flex; align-items: center; gap: 6px; }
-
-/* Actions row under Pengaturan */
-#pengaturan-actions-row{ display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
-#pengaturan-actions-row .btn{ min-width: max(132px, 16ch); line-height: 1.2; }
-
-/* Keep mobile comfortable */
-@media (max-width: 680px){
-  #secOptions .row label.muted{ flex-basis: 100%; max-width: none; margin-bottom: 2px; }
-  #secOptions .row input.input, #secOptions .row select.input, #secOptions .row .input{ flex-basis: 100%; min-width: 0; }
-}
-
-/* Table wrapper corners and spacing */
-#tableWrap > div{ border-radius: 12px; overflow: hidden; }
-
-/* Do not affect print */
-@media print{
-  .pengaturan-card{ border: 0; box-shadow: none; padding: 0; }
-}
-</style>
-
-
-<style>
-/* ===== Global 8pt typography & weight rules ===== */
-html, body { font-size: 8pt !important; }
-body, body * { font-size: 8pt !important; line-height: 1.35; }
-/* Normal-weight everywhere by default */
-h1, h2, h3, h4, h5, h6,
-th, .th, strong, b, label, summary,
-.btn, .chip, .muted { font-weight: normal !important; }
-/* Keep only the app title bold */
-.topbar h1, .header h1, h1.app-title, h1#appTitle { font-weight: 700 !important; }
-/* Preserve existing white title on screen (already set elsewhere), but black on print */
-@media print{
-  .topbar h1, .header h1, h1.app-title, h1#appTitle { color: #000 !important; }
-  body, body * { color: #000 !important; }
-}
-</style>
-
-
-<style>
-/* Icon-only delete buttons */
-.btn.icon{
-  display:inline-flex; align-items:center; justify-content:center;
-  padding:6px; min-width:auto; width:30px; height:30px; border-radius:10px;
-}
-.btn.icon.small{ width:26px; height:26px; padding:4px; border-radius:8px; }
-.btn.icon svg{ width:14px; height:14px; display:block; }
-@media (max-width: 900px){
-  .btn.icon{ width:34px; height:34px; }
-  .btn.icon.small{ width:30px; height:30px; }
-  .btn.icon svg{ width:16px; height:16px; }
-}
-</style>
-
-
-<style>
-#mainActionsFixed{ position:relative; z-index:5; margin:10px 0 14px; display:flex; flex-wrap:wrap; gap:8px; }
-#mainActionsFixed .btn{ min-height:32px; padding:6px 10px; }
-@media print{ #mainActionsFixed{ visibility: hidden !important; } }
-</style>
-
-
-<style>
-/* ===== Card Mode: compact smartphone layout ===== */
-@media (max-width: 430px) {
-  /* Card shell */
-  .cards, #cardsWrap, .cards-container{ padding: 6px !important; }
-  .worker-card, .card{
-    width: 100% !important;
-    max-width: 100% !important;
-    padding: 8px 10px !important;
-    border-radius: 10px !important;
-    font-size: 12px !important;
-    line-height: 1.25 !important;
-  }
-  /* Card header & titles */
-  .worker-card h3, .card h3{
-    font-size: 13px !important;
-    margin: 0 0 6px !important;
-    line-height: 1.2 !important;
-  }
-  /* Grid/rows inside cards */
-  .worker-card .row, .card .row{
-    display: grid !important;
-    grid-template-columns: 1fr !important;
-    gap: 6px !important;
-  }
-  /* Labels & inline fields */
-  .worker-card label, .card label{
-    font-size: 12px !important;
-  }
-  .worker-card .field, .card .field{
-    display: flex; align-items: center; justify-content: space-between;
-    gap: 6px;
-  }
-  /* Inputs/selects/buttons inside cards */
-  .worker-card input, .worker-card select,
-  .card input, .card select{
-    height: 28px !important;
-    padding: 2px 6px !important;
-    font-size: 12px !important;
-  }
-  .worker-card .bonus-line input, .card .bonus-line input{
-    height: 28px !important;
-    padding: 2px 6px !important;
-    max-width: 120px !important;
-  }
-  .worker-card .btn, .card .btn{
-    min-height: 28px !important;
-    padding: 4px 8px !important;
-    font-size: 12px !important;
-  }
-  .worker-card .btn.icon, .card .btn.icon{
-    width: 28px !important; height: 28px !important;
-  }
-  .worker-card .btn.icon svg, .card .btn.icon svg{
-    width: 16px !important; height: 16px !important;
-  }
-  /* Tighten vertical rhythm between sections */
-  .worker-card + .worker-card, .card + .card{ margin-top: 8px !important; }
-  /* Totals row text smaller but readable */
-  .worker-card .total, .card .total{
-    font-size: 12px !important;
-  }
-}
-</style>
-
-<style>
-
-/* === Injected by ChatGPT: Table vertical scroll with sticky header/footer === */
-#tableWrap{
-  overflow-y: auto;              /* enable vertical scroll */
-  max-height: min(72vh, 720px);  /* contain table height */
-}
-
-/* sticky header */
-#tbl thead th{
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: var(--card, #fff);
-}
-
-/* sticky footer total */
-#tbl tfoot td{
-  position: sticky;
-  bottom: 0;
-  z-index: 1;
-  background: var(--card, #fff);
-  box-shadow: 0 -1px 0 var(--border, rgba(0,0,0,.08));
-}
-
-/* mobile: give more room accounting for search/FAB bars */
-@media (max-width: 768px){
-  #tableWrap{
-    max-height: calc(100vh - 220px);
-  }
-}
-
-</style>
-<style>
-
-/* === Injected by ChatGPT (tidy): sticky header/footer & table polish === */
-:root{
-  --c-bg: var(--card, #ffffff);
-  --c-border: var(--border, rgba(0,0,0,.08));
-  --c-text: var(--text, #111827);
-  --c-muted: var(--muted, #6b7280);
-}
-
-#tableWrap{
-  position: relative;
-  overflow: auto; /* both axes */
-  background: var(--c-bg);
-  border: 1px solid var(--c-border);
-  border-radius: 12px;
-}
-
-/* Ensure inner min-width container keeps the table wide */
-#tableWrap > div{
-  border: none !important;        /* avoid double border */
-  border-radius: 12px;
-}
-
-/* Base table polish */
-#tbl{
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  table-layout: fixed;
-  color: var(--c-text);
-  font-size: 12px;
-}
-#tbl th, #tbl td{
-  padding: 8px 10px;
-  line-height: 1.2;
-  vertical-align: middle;
-  border-bottom: 1px solid var(--c-border);
-  background: var(--c-bg);
-  box-sizing: border-box;
-}
-#tbl thead th{
-  font-weight: 600;
-  text-transform: none;
-  letter-spacing: .01em;
-  white-space: nowrap;
-}
-
-/* Zebra rows for readability */
-#tbl tbody tr:nth-child(odd) td{ background: color-mix(in oklab, var(--c-bg) 92%, black); }
-#tbl tbody tr:hover td{ background: color-mix(in oklab, var(--c-bg) 86%, black); }
-
-/* Sticky overlay containers */
-#tableWrap .sticky-header,
-#tableWrap .sticky-footer{
-  position: sticky;
-  left: 0; right: 0;
-  z-index: 40;
-  background: var(--c-bg);
-}
-#tableWrap .sticky-header{
-  top: 0;
-  box-shadow: 0 1px 0 var(--c-border), 0 6px 10px rgba(0,0,0,.04);
-}
-#tableWrap .sticky-footer{
-  bottom: 0;
-  box-shadow: 0 -1px 0 var(--c-border), 0 -6px 10px rgba(0,0,0,.04);
-}
-#tableWrap .sticky-header table,
-#tableWrap .sticky-footer table{
-  width: 100%;
-  border-collapse: separate;
-  border-spacing: 0;
-  table-layout: fixed;
-}
-#tableWrap .sticky-header th,
-#tableWrap .sticky-footer td{
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--c-border);
-}
-#tableWrap .sticky-footer td{
-  border-top: 1px solid var(--c-border);
-}
-
-/* Hide original thead/tfoot to prevent double lines */
-#tbl thead.is-hidden th,
-#tbl tfoot.is-hidden td{ visibility: hidden !important; }
-
-/* Prevent overlap of first/last rows by adding padding via CSS vars */
-#tableWrap.padding-for-sticky{
-  --stickyHeadH: 0px;
-  --stickyFootH: 0px;
-  padding-top: var(--stickyHeadH);
-  padding-bottom: var(--stickyFootH);
-}
-
-/* Compact on mobile */
-@media (max-width: 768px){
-  #tbl{ font-size: 11px; }
-  #tbl th, #tbl td{ padding: 7px 8px; }
-  #tableWrap{ max-height: calc(100vh - 200px); }
-}
-
-</style>
-<style>
-
-/* === Injected by ChatGPT: flush-to-container (no top/bottom gap) === */
-#tableWrap.padding-for-sticky{
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-}
-
-#tbl tbody tr:first-child td{ border-top: 1px solid var(--c-border); }
-#tbl tbody::before{
-  content: "";
-  display: table-row;
-  height: var(--stickyHeadH, 0px);
-}
-#tbl tbody::after{
-  content: "";
-  display: table-row;
-  height: var(--stickyFootH, 0px);
-}
-
-</style>
-
-
-<!-- === Hide Kelas & Group: CSS v2 === -->
-<style>
-/* Fallback by column index */
-body.hide-cg #tbl thead th:nth-child(3),
-body.hide-cg #tbl tbody td:nth-child(3),
-body.hide-cg #tbl thead th:nth-child(4),
-body.hide-cg #tbl tbody td:nth-child(4) {
-  visibility: hidden !important;
-  width: 0 !important;
-  padding: 0 !important;
-  border: 0 !important;
-}
-
-/* Class-based (preferred): applied by JS after detecting the real indices */
-body.hide-cg #tbl th.col-kelas,
-body.hide-cg #tbl td.col-kelas,
-body.hide-cg #tbl th.col-group,
-body.hide-cg #tbl td.col-group {
-  visibility: hidden !important;
-  width: 0 !important;
-  padding: 0 !important;
-  border: 0 !important;
-}
-
-/* Hide in Card view (already tagged via JS/observer) */
-body.hide-cg #cardsWrap .kv.hide-cg { visibility: hidden !important; }
-
-.settings-row { display:flex; align-items:center; gap:.5rem; margin:.5rem 0; }
-.settings-row input[type="checkbox"] { transform: translateY(1px); }
-</style>
-
-<style>
-/* Aggressive: any element tagged as hide-cg-el disappears when hide mode is on */
-body.hide-cg .hide-cg-el { visibility: hidden !important; visibility: hidden !important; width:0 !important; padding:0 !important; margin:0 !important; border:0 !important; }
-</style>
-
-
-<style>
-/* === Safe hide: keep layout aligned by hiding content only === */
-body.hide-cg #tbl thead th:nth-child(3),
-body.hide-cg #tbl tbody td:nth-child(3),
-body.hide-cg #tbl tfoot td:nth-child(3),
-body.hide-cg #tbl thead th:nth-child(4),
-body.hide-cg #tbl tbody td:nth-child(4),
-body.hide-cg #tbl tfoot td:nth-child(4),
-body.hide-cg #tbl th.col-kelas,
-body.hide-cg #tbl td.col-kelas,
-body.hide-cg #tbl th.col-group,
-body.hide-cg #tbl td.col-group {
-  visibility: hidden !important;
-  padding: 0 !important;
-  border: 0 !important;
-}
-
-/* Card fields already handled via .kv.hide-cg */
-</style>
-
-
-<style>
-/* === Injected: Logo finger heart above title === */
-.topbar{
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-.logo-mark{
-  font-size: 480px;
-  line-height: 1;
-  color: currentColor; /* white on-screen (already forced), black on print */
-}
-@media print{
-  .logo-mark{ color: #000 !important; }
-}
-</style>
-
-
-<style>
-/* === Injected: Make logo undeniably large & responsive === */
-.topbar{ overflow: visible; }
-div.logo-mark.logo-mark{ font-size: min(60vh,80vw) !important; line-height: 1 !important; }
-@media print{
-  div.logo-mark.logo-mark{ font-size: 64pt !important; color:#000 !important; }
-}
-</style>
-
-
-<style>
-/* === Injected: Set logo to ~30% of viewport === */
-.topbar .logo-mark{ font-size: min(30vh,30vw) !important; line-height: 1 !important; }
-@media print{
-  .topbar .logo-mark{ font-size: 36pt !important; }
-}
-</style>
-
-
-<style>
-/* === Injected: Set logo to ~15% of viewport === */
-.topbar .logo-mark{ font-size: min(15vh,15vw) !important; line-height: 1 !important; }
-@media print{
-  .topbar .logo-mark{ font-size: 28pt !important; }
-}
-</style>
-
-
-<style>
-/* === Injected: Set logo to ~7.5% of viewport === */
-.topbar .logo-mark{ font-size: min(7.5vh,7.5vw) !important; line-height: 1 !important; }
-@media print{
-  .topbar .logo-mark{ font-size: 18pt !important; }
-}
-</style>
-
-
-<style>
-/* === Injected: Tighten table header-body gap === */
-table { border-collapse: collapse !important; border-spacing: 0 !important; }
-thead { margin-bottom: 0 !important; }
-tbody { margin-top: 0 !important; }
-thead th { padding-bottom: 2px !important; }
-tbody td { padding-top: 2px !important; }
-</style>
-
-<style>
-  /* Lebarkan kolom BONUS 3× */
-  #tbl th:nth-child(16),
-  #tbl td:nth-child(16){
-    width: 15ch;              /* pakai ch supaya cukup untuk angka panjang */
-  }
-  /* Pastikan input-nya mengikuti lebar sel */
-  #tbl td:nth-child(16) .input,
-  #tbl td:nth-child(16) input{
-    width: 100%;
-    max-width: none;
-  }
-
-  /* Opsional: beri ruang ekstra di layar kecil */
-  @media (max-width: 768px){
-    #tbl th:nth-child(16),
-    #tbl td:nth-child(16){ width: 15ch; }
-  }
-
-/* ---- Force logo to black & white (keep size the same) ---- */
-.logo-mark, .logo, .brand-mark {
-  -webkit-filter: grayscale(100%) contrast(120%) !important;
-  filter: grayscale(100%) contrast(120%) !important;
-}
-.logo-mark svg, .logo svg {
-  filter: grayscale(100%) contrast(120%) !important;
-}
-
-.logo-mark, .logo, .brand-mark { color: #000 !important; }
-</style>
-
-<style>
-  #mainActionsFixed{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
-  #mainActionsFixed #periodRow{ order:0; }
-  @media (max-width:640px){
-    #mainActionsFixed #periodRow{ width:100%; order:-1; }
-  }
-</style>
-
-<style>
-  .date-wrap{ display:inline-flex; align-items:center; gap:4px; border-radius:10px; }
-  .date-wrap .cal-btn{
-    border:1px solid var(--border,#d0d5dd);
-    background: var(--bg,#fff);
-    padding:6px; border-radius:8px; cursor:pointer; line-height:0;
-  }
-  .date-wrap .cal-btn:hover{ background:#f9fafb; }
-  /* Popup calendar */
-  .mini-cal{
-    position:absolute; z-index:9999; background:#fff; border:1px solid #d0d5dd; border-radius:12px;
-    box-shadow:0 10px 30px rgba(0,0,0,.08); width:280px; overflow:hidden;
-  }
-  .mini-cal header{
-    display:flex; align-items:center; justify-content:space-between; padding:10px 12px; border-bottom:1px solid #eef2f7;
-    font-weight:600;
-  }
-  .mini-cal header .nav{ display:flex; gap:6px; }
-  .mini-cal header .nav button{ padding:4px 8px; border:1px solid #d0d5dd; background:#fff; border-radius:8px; cursor:pointer; }
-  .mini-cal .grid{ display:grid; grid-template-columns: repeat(7, 1fr); gap:4px; padding:10px; }
-  .mini-cal .dow{ text-align:center; font-size:12px; color:#667085; }
-  .mini-cal .day{
-    text-align:center; padding:8px 0; border-radius:8px; cursor:pointer; border:1px solid transparent;
-  }
-  .mini-cal .day:hover{ background:#f2f4f7; }
-  .mini-cal .day.today{ border-color:#d0d5dd; }
-  .mini-cal .day.out{ color:#98a2b3; }
-  .mini-cal .footer{ display:flex; justify-content:flex-end; gap:8px; padding:10px; border-top:1px solid #eef2f7; }
-  .mini-cal .footer button{ padding:6px 10px; border:1px solid #d0d5dd; background:#fff; border-radius:8px; cursor:pointer; }
-</style>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Upah Tukang — Form</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8fafc;
+      --surface: #ffffff;
+      --surface-muted: #f1f5f9;
+      --text: #0f172a;
+      --text-muted: #64748b;
+      --line: rgba(148,163,184,0.4);
+      --accent: #f97316;
+      --accent-strong: #ea580c;
+      --radius-lg: 20px;
+      --radius-md: 14px;
+      --radius-sm: 10px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0f172a;
+        --surface: #111b2e;
+        --surface-muted: #15233a;
+        --text: #e2e8f0;
+        --text-muted: #94a3b8;
+        --line: rgba(71,85,105,0.6);
+        --accent: #f97316;
+        --accent-strong: #fb923c;
+      }
+    }
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      line-height: 1.5;
+    }
+    a { color: inherit; text-decoration: none; }
+    button { font: inherit; color: inherit; cursor: pointer; }
+    input, select, textarea { font: inherit; color: inherit; background: transparent; }
+    .shell { max-width: 1200px; margin: 0 auto; padding: 0 1.5rem; }
+    .app-header {
+      position: sticky;
+      top: 0;
+      z-index: 40;
+      background: rgba(255,255,255,0.85);
+      border-bottom: 1px solid rgba(148,163,184,0.35);
+      backdrop-filter: blur(14px);
+    }
+    @media (prefers-color-scheme: dark) {
+      .app-header {
+        background: rgba(15,23,42,0.85);
+        border-bottom-color: rgba(148,163,184,0.25);
+      }
+    }
+    .header-inner {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      padding: 1rem 0;
+    }
+    .eyebrow {
+      margin: 0;
+      font-size: 0.7rem;
+      letter-spacing: 0.16em;
+      text-transform: uppercase;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+    #appTitle {
+      margin: 0;
+      font-size: 1.4rem;
+      font-weight: 700;
+    }
+    .nav-links {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+    .nav-links a {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.5rem 0.9rem;
+      border-radius: 999px;
+      border: 1px solid transparent;
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: var(--text-muted);
+      transition: border-color 0.2s ease, color 0.2s ease;
+    }
+    .nav-links a:hover {
+      border-color: var(--line);
+      color: var(--text);
+    }
+    .main-stack {
+      display: flex;
+      flex-direction: column;
+      gap: 1.5rem;
+      padding: 2rem 0 4rem;
+    }
+    .card {
+      background: var(--surface);
+      border-radius: var(--radius-lg);
+      padding: 1.6rem;
+      border: 1px solid rgba(148,163,184,0.24);
+      box-shadow: 0 10px 30px rgba(15,23,42,0.08);
+    }
+    @media (prefers-color-scheme: dark) {
+      .card {
+        box-shadow: 0 16px 40px rgba(2,6,23,0.55);
+        border-color: rgba(148,163,184,0.2);
+      }
+    }
+    .stack { display: flex; flex-direction: column; gap: 1rem; }
+    .row { display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center; }
+    .grid { display: grid; gap: 0.75rem; }
+    .section-header {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 1.25rem;
+      align-items: flex-start;
+    }
+    .section-header h2 {
+      margin: 0;
+      font-size: 1.05rem;
+      font-weight: 600;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+    }
+    .field .muted {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+    .muted {
+      color: var(--text-muted);
+      font-size: 0.85rem;
+    }
+    .input {
+      width: 100%;
+      border-radius: var(--radius-md);
+      border: 1px solid var(--line);
+      background: var(--surface);
+      padding: 0.55rem 0.8rem;
+      min-height: 2.5rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+    .input:focus {
+      border-color: var(--accent);
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent);
+      outline: 0;
+    }
+    .input.right { text-align: right; }
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+      padding: 0.55rem 1rem;
+      font-weight: 600;
+      font-size: 0.9rem;
+      transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+    }
+    .btn:hover {
+      border-color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 14%, var(--surface));
+    }
+    .btn.primary {
+      background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+      border-color: var(--accent-strong);
+      color: #fff;
+    }
+    .btn.primary:hover { transform: translateY(-1px); }
+    .btn.small { padding: 0.45rem 0.85rem; font-size: 0.8rem; }
+    .btn.ghost { border-style: dashed; background: transparent; }
+    .btn[disabled] { opacity: 0.5; cursor: not-allowed; }
+    .action-shell { gap: 1.25rem; }
+    #periodRow .field { min-width: 200px; }
+    .date-wrap { display: inline-flex; align-items: center; gap: 0.5rem; }
+    .cal-btn {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--surface-muted);
+      padding: 0.4rem;
+      line-height: 0;
+      transition: border-color 0.2s ease, background 0.2s ease;
+    }
+    .cal-btn:hover {
+      border-color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 18%, var(--surface-muted));
+    }
+    .cal-btn svg { width: 18px; height: 18px; color: var(--text-muted); }
+    .search-field { min-width: 220px; }
+    .totals-panel {
+      border-radius: var(--radius-lg);
+      border: 1px solid rgba(148,163,184,0.24);
+      background: var(--surface-muted);
+      padding: 1.1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    .totals-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 0.75rem;
+    }
+    .total-chip {
+      border-radius: var(--radius-md);
+      border: 1px solid rgba(148,163,184,0.28);
+      background: var(--surface);
+      padding: 0.75rem 0.9rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.3rem;
+    }
+    .total-chip .label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+      font-weight: 600;
+    }
+    .total-chip .value { font-size: 1.1rem; font-weight: 700; }
+    .total-chip.highlight {
+      border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+      background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+    }
+    .totals-actions { display: flex; justify-content: flex-end; gap: 0.5rem; }
+    details { border-radius: var(--radius-lg); }
+    details > summary {
+      list-style: none;
+      cursor: pointer;
+      font-weight: 600;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      font-size: 0.95rem;
+    }
+    details > summary::-webkit-details-marker { display: none; }
+    details > summary::after {
+      content: '▾';
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      transition: transform 0.2s ease;
+    }
+    details[open] > summary::after { transform: rotate(180deg); }
+    #secOptions .options-body { margin-top: 1rem; gap: 1.25rem; }
+    #secOptions details.subcard {
+      background: var(--surface-muted);
+      border-radius: var(--radius-lg);
+      border: 1px solid rgba(148,163,184,0.22);
+      padding: 1rem 1.1rem;
+    }
+    #secOptions details.subcard > summary { font-size: 0.9rem; }
+    #secOptions details.subcard > summary::after { content: '▸'; }
+    #secOptions details.subcard[open] > summary::after { transform: rotate(90deg); }
+    #secOptions details.subcard[open] > summary { margin-bottom: 0.75rem; }
+    .rate-grid { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+    .field.compact { min-width: 140px; max-width: 200px; }
+    .input-compact { max-width: 160px; }
+    .chip-list { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      padding: 0.35rem 0.75rem;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: var(--surface);
+      font-size: 0.85rem;
+    }
+    .chip button {
+      border: 0;
+      background: none;
+      color: var(--text-muted);
+      cursor: pointer;
+      font-size: 0.9em;
+    }
+    .table-card .table-container {
+      overflow-x: auto;
+      border-radius: var(--radius-lg);
+      border: 1px solid rgba(148,163,184,0.24);
+    }
+    .table-card table {
+      width: 100%;
+      min-width: 1024px;
+      border-collapse: separate;
+      border-spacing: 0;
+    }
+    .table-card th,
+    .table-card td {
+      padding: 0.65rem 0.75rem;
+      border-bottom: 1px solid rgba(148,163,184,0.22);
+      vertical-align: top;
+    }
+    .table-card thead th {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+      color: var(--text-muted);
+      background: var(--surface-muted);
+      font-weight: 600;
+    }
+    .table-card tbody tr:nth-child(odd) td {
+      background: color-mix(in srgb, var(--surface-muted) 55%, transparent);
+    }
+    .table-card tbody tr:hover td {
+      background: color-mix(in srgb, var(--accent) 10%, var(--surface));
+    }
+    .table-card tfoot td {
+      font-weight: 700;
+      background: var(--surface-muted);
+    }
+    .center { text-align: center; }
+    .right { text-align: right; }
+    .sum { font-weight: 700; font-size: 0.95rem; }
+    .scroll-x { overflow-x: auto; }
+    .worker-card {
+      border-radius: var(--radius-lg);
+      border: 1px solid rgba(148,163,184,0.24);
+      background: var(--surface);
+      padding: 1rem 1.2rem;
+      margin-bottom: 0.75rem;
+      box-shadow: 0 8px 24px rgba(15,23,42,0.08);
+    }
+    .worker-card.zebra-a { background: color-mix(in srgb, var(--surface) 85%, var(--surface-muted) 20%); }
+    .worker-card.zebra-b { background: color-mix(in srgb, var(--surface) 75%, var(--surface-muted) 35%); }
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .name { font-weight: 700; font-size: 1rem; }
+    .daygrid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 0.75rem;
+      margin-top: 1rem;
+    }
+    .daygrid .item {
+      border-radius: var(--radius-md);
+      border: 1px dashed rgba(148,163,184,0.28);
+      padding: 0.75rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+    .kv { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-top: 0.5rem; }
+    .cellstack { display: flex; flex-direction: column; align-items: flex-end; gap: 0.15rem; }
+    .cellstack .cnt { font-size: 0.7rem; color: var(--text-muted); }
+    #pengaturan-actions-row { gap: 0.75rem; flex-wrap: wrap; }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      padding: 0.35rem 0.75rem;
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+    .table-card .sticky-header,
+    .table-card .sticky-footer {
+      position: sticky;
+      left: 0;
+      right: 0;
+      z-index: 15;
+      background: var(--surface);
+    }
+    .table-card .sticky-header {
+      top: 0;
+      box-shadow: 0 1px 0 rgba(15,23,42,0.1);
+    }
+    .table-card .sticky-footer {
+      bottom: 0;
+      box-shadow: 0 -1px 0 rgba(15,23,42,0.08);
+    }
+    .table-card .sticky-header table,
+    .table-card .sticky-footer table {
+      width: 100%;
+      border-collapse: separate;
+      border-spacing: 0;
+    }
+    .table-card .sticky-header th,
+    .table-card .sticky-footer td {
+      padding: 0.65rem 0.75rem;
+    }
+    #tableWrap.padding-for-sticky {
+      padding-top: var(--stickyHeadH, 0px);
+      padding-bottom: var(--stickyFootH, 0px);
+    }
+    .no-print {}
+    @media print {
+      .app-header, .nav-links, .btn, .totals-panel, .no-print { display: none !important; }
+      body { background: #fff; color: #000; }
+      .card { box-shadow: none !important; border-color: #bbb; }
+      .table-card .table-container { border-color: #444; }
+      table, thead, tbody, tfoot, tr, td, th { background: transparent !important; color: #000 !important; }
+    }
+    body.hide-cg #tbl th.col-kelas,
+    body.hide-cg #tbl td.col-kelas,
+    body.hide-cg #tbl th.col-group,
+    body.hide-cg #tbl td.col-group {
+      display: none !important;
+    }
+    body.hide-cg #tbl thead th:nth-child(3),
+    body.hide-cg #tbl tbody td:nth-child(3),
+    body.hide-cg #tbl thead th:nth-child(4),
+    body.hide-cg #tbl tbody td:nth-child(4),
+    body.hide-cg #tbl tfoot td:nth-child(3),
+    body.hide-cg #tbl tfoot td:nth-child(4) {
+      display: none !important;
+    }
+    body.hide-cg #cardsWrap .kv.hide-cg { display: none !important; }
+    .mini-cal {
+      position: absolute;
+      z-index: 60;
+      background: var(--surface);
+      border: 1px solid rgba(148,163,184,0.3);
+      border-radius: var(--radius-lg);
+      box-shadow: 0 16px 40px rgba(15,23,42,0.18);
+      width: 280px;
+      overflow: hidden;
+    }
+    .mini-cal header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.75rem 1rem;
+      border-bottom: 1px solid rgba(148,163,184,0.2);
+      font-weight: 600;
+    }
+    .mini-cal header .nav { display: flex; gap: 0.4rem; }
+    .mini-cal header .nav button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--surface);
+      padding: 0.35rem 0.6rem;
+    }
+    .mini-cal .grid {
+      display: grid;
+      grid-template-columns: repeat(7, 1fr);
+      gap: 0.4rem;
+      padding: 0.85rem;
+    }
+    .mini-cal .dow {
+      text-align: center;
+      font-size: 0.75rem;
+      color: var(--text-muted);
+    }
+    .mini-cal .day {
+      text-align: center;
+      padding: 0.6rem 0;
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      border: 1px solid transparent;
+      transition: background 0.2s ease, border-color 0.2s ease;
+    }
+    .mini-cal .day:hover { background: color-mix(in srgb, var(--accent) 12%, var(--surface)); }
+    .mini-cal .day.today { border-color: var(--accent); }
+    .mini-cal .day.out { color: var(--text-muted); }
+    .mini-cal .footer {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      border-top: 1px solid rgba(148,163,184,0.2);
+    }
+    .mini-cal .footer button {
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--line);
+      background: var(--surface);
+      padding: 0.45rem 0.8rem;
+    }
+    @media (max-width: 900px) {
+      .header-inner { flex-direction: column; align-items: flex-start; }
+      .nav-links { width: 100%; }
+      .section-header { flex-direction: column; align-items: stretch; }
+      .totals-panel {
+        position: sticky;
+        bottom: 1rem;
+        z-index: 30;
+        margin: 0 -0.5rem;
+        backdrop-filter: blur(12px);
+        box-shadow: 0 -12px 32px rgba(15,23,42,0.18);
+      }
+    }
+  </style>
 </head>
 <body>
-  <div class="container">
-    <div class="topbar">
-  <div class="logo-mark" style="font-size:min(7.5vh,7.5vw) !important; line-height:1; line-height:1; line-height:1; line-height:1; display:block; margin-top:8px;" title="finger heart" aria-label="finger heart">🫰</div>
-<h1 class="app-title">Kalkulator Upah 7 Hari</h1></div>
+  <header class="app-header">
+    <div class="shell header-inner">
+      <div>
+        <p class="eyebrow">Upah Tukang</p>
+        <h1 id="appTitle">Kalkulator Upah 7 Hari</h1>
+      </div>
+      <nav class="nav-links">
+        <a href="/index.html">Dasbor</a>
+        <a href="/rekap.html">Rekap</a>
+      </nav>
+    </div>
+  </header>
 
-<div class="main-actions" id="mainActionsFixed">
-    <div class="row" id="periodRow" style="gap:8px; align-items:center; flex-wrap:wrap; margin-right:auto;">
-    <label class="muted">Periode</label>
-    <span class="date-wrap">
-  <input type="date" id="periodStart" class="input" style="width:160px;">
-  <button type="button" class="cal-btn" data-cal-for="periodStart" aria-label="Buka kalender">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <rect x="3" y="5" width="18" height="16" rx="2" ry="2" stroke="currentColor" />
-      <path d="M16 3v4M8 3v4M3 9h18" stroke="currentColor" />
-    </svg>
-  </button>
-</span>
-    <span class="muted">s/d</span>
-    <span class="date-wrap">
-  <input type="date" id="periodEnd" class="input" style="width:160px;">
-  <button type="button" class="cal-btn" data-cal-for="periodEnd" aria-label="Buka kalender">
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <rect x="3" y="5" width="18" height="16" rx="2" ry="2" stroke="currentColor" />
-      <path d="M16 3v4M8 3v4M3 9h18" stroke="currentColor" />
-    </svg>
-  </button>
-</span>
-  </div>
-<button class="btn" onclick="try{saveAll&&saveAll()}catch(_){ if (typeof save==='function') save('rows', window.rows); else alert('Fungsi simpan tidak tersedia'); }">Simpan</button>
-  <button class="btn" onclick="window.print()">Cetak</button>
-  <button class="btn" onclick="try{downloadCSV&&downloadCSV()}catch(_){alert('downloadCSV tidak ditemukan')}">Unduh CSV</button>
-  <button class="btn" onclick="try{downloadJSON&&downloadJSON()}catch(_){alert('downloadJSON tidak ditemukan')}">Unduh JSON</button>
-  <button class="btn small" onclick="restoreDefaultRows()">Kosongkan</button>
-  
-  <button class="btn primary" onclick="addWorker()">+ Pekerja</button>
-</div>
-
-
-<details class="card collapsible" id="secOptions">
-
-<!-- === Toggle: Hide Kelas & Group === -->
-<div class="settings-row">
-  <input type="checkbox" id="toggleHideCG">
-  <label for="toggleHideCG">Sembunyikan kolom <b>Kelas</b> & <b>Group</b> (Tabel & Card)</label>
-</div>
-
-      <summary><span class="sum-title">Pengaturan</span></summary>
-<div class="card pengaturan-card" style="margin-top:8px; padding:12px;"><div class="row">
-        <div style="width:220px;">
-          <label class="muted">Senior</label>
-          <input id="rateSenior" type="number" class="input" oninput="classRates['Senior']=Number(this.value||0); rerender();" />
+  <main class="shell main-stack">
+    <section class="card stack">
+      <div class="section-header">
+        <div>
+          <h2>Periode &amp; Aksi</h2>
+          <p class="muted">Setel rentang tanggal kerja lalu simpan atau ekspor data.</p>
         </div>
-        <div style="width:220px;">
-          <label class="muted">Tukang</label>
-          <input id="rateTukang" type="number" class="input" oninput="classRates['Tukang']=Number(this.value||0); rerender();" />
-        </div>
-        <div style="width:220px;">
-          <label class="muted">Kenek</label>
-          <input id="rateKenek" type="number" class="input" oninput="classRates['Kenek']=Number(this.value||0); rerender();" />
+        <div class="field search-field">
+          <label class="muted" for="searchName">Cari Pekerja</label>
+          <input id="searchName" type="search" class="input" placeholder="Cari nama pekerja…" autocomplete="off">
         </div>
       </div>
-
-
-      <div class="subcard">
-<h3 style="margin:0 0 6px;">Tarif per Kelas (Rp/hari)</h3>
-
-      <div class="row" style="justify-content:flex-end; gap:8px;"><button class="btn small" onclick="restoreDefaultRates()">Kembalikan Tarif Default</button>
+      <div id="mainActionsFixed" class="stack action-shell">
+        <div id="periodRow" class="row">
+          <div class="field">
+            <label class="muted" for="periodStart">Mulai</label>
+            <span class="date-wrap">
+              <input type="date" id="periodStart" class="input">
+              <button type="button" class="cal-btn" data-cal-for="periodStart" aria-label="Buka kalender mulai">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <rect x="3" y="5" width="18" height="16" rx="2" ry="2" stroke="currentColor" />
+                  <path d="M16 3v4M8 3v4M3 9h18" stroke="currentColor" />
+                </svg>
+              </button>
+            </span>
+          </div>
+          <div class="field">
+            <label class="muted" for="periodEnd">Selesai</label>
+            <span class="date-wrap">
+              <input type="date" id="periodEnd" class="input">
+              <button type="button" class="cal-btn" data-cal-for="periodEnd" aria-label="Buka kalender selesai">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <rect x="3" y="5" width="18" height="16" rx="2" ry="2" stroke="currentColor" />
+                  <path d="M16 3v4M8 3v4M3 9h18" stroke="currentColor" />
+                </svg>
+              </button>
+            </span>
+          </div>
+        </div>
+        <div class="row">
+          <button class="btn" onclick="try{saveAll&&saveAll()}catch(_){ if (typeof save==='function') save('rows', window.rows); else alert('Fungsi simpan tidak tersedia'); }">Simpan</button>
+          <button class="btn" onclick="window.print()">Cetak</button>
+          <button class="btn" onclick="try{downloadCSV&&downloadCSV()}catch(_){alert('downloadCSV tidak ditemukan')}">Unduh CSV</button>
+          <button class="btn" onclick="try{downloadJSON&&downloadJSON()}catch(_){alert('downloadJSON tidak ditemukan')}">Unduh JSON</button>
+          <button class="btn small" onclick="restoreDefaultRows()">Kosongkan</button>
+          <button class="btn primary" onclick="addWorker()">+ Pekerja</button>
+        </div>
       </div>
-<div class="row">
-  <label class="muted">Ambang Uang Beras</label>
-  <input id="thresholdInput" type="number" step="1" min="0" style="width:160px;" />
-  <label class="muted">Nilai Uang Beras</label>
-  <input id="berasInput" type="number" step="1" min="0" style="width:140px;" />
-  <button class="btn small" onclick="updateBerasRule()">Terapkan</button>
-</div>
-
-
-      <div class="subcard">
-<h3 style="margin:0 0 6px;">Master Rumah</h3>
-
-      <div class="row">
-        <input id="inpRumah" class="input" style="width:260px;" placeholder="mis. A11 atau C1" />
-        <button class="btn small" onclick="addRumah()">Tambah</button>
-        <button class="btn small" onclick="clearRumah()">Kosongkan Daftar</button>
-        <button class="btn small" onclick="restoreDefaultRumah()">Pulihkan Default</button>
-      
+      <div class="totals-panel no-print">
+        <div class="totals-grid">
+          <div class="total-chip">
+            <span class="label">Total Hari</span>
+            <span id="pillHari" class="value">0</span>
+          </div>
+          <div class="total-chip">
+            <span class="label">Upah Pokok</span>
+            <span id="pillPokok" class="value">Rp 0</span>
+          </div>
+          <div class="total-chip">
+            <span class="label">Uang Beras</span>
+            <span id="pillBeras" class="value">Rp 0</span>
+          </div>
+          <div class="total-chip highlight">
+            <span class="label">Total Bayar</span>
+            <span id="pillTotal" class="value">Rp 0</span>
+          </div>
+        </div>
+        <div class="totals-actions">
+          <button class="btn ghost" onclick="setView(toggleView())">Ganti Mode</button>
+        </div>
       </div>
+    </section>
 
+    <details id="secOptions" class="card">
+      <summary>Pengaturan</summary>
+      <div class="options-body stack">
+        <details id="secRates" class="subcard">
+          <summary>Tarif &amp; Aturan</summary>
+          <div class="stack">
+            <div class="grid rate-grid">
+              <div class="field compact">
+                <label class="muted" for="rateSenior">Senior</label>
+                <input id="rateSenior" type="number" class="input input-compact" oninput="classRates['Senior']=Number(this.value||0); rerender();">
+              </div>
+              <div class="field compact">
+                <label class="muted" for="rateTukang">Tukang</label>
+                <input id="rateTukang" type="number" class="input input-compact" oninput="classRates['Tukang']=Number(this.value||0); rerender();">
+              </div>
+              <div class="field compact">
+                <label class="muted" for="rateKenek">Kenek</label>
+                <input id="rateKenek" type="number" class="input input-compact" oninput="classRates['Kenek']=Number(this.value||0); rerender();">
+              </div>
+            </div>
+            <div class="row" style="justify-content:flex-end;">
+              <button class="btn small" type="button" onclick="restoreDefaultRates()">Pulihkan Tarif Default</button>
+            </div>
+            <div class="row">
+              <div class="field compact">
+                <label class="muted" for="thresholdInput">Ambang Uang Beras</label>
+                <input id="thresholdInput" type="number" step="1" min="0" class="input input-compact">
+              </div>
+              <div class="field compact">
+                <label class="muted" for="berasInput">Nilai Uang Beras</label>
+                <input id="berasInput" type="number" step="1" min="0" class="input input-compact">
+              </div>
+              <button class="btn small" type="button" onclick="updateBerasRule()">Terapkan</button>
+            </div>
+          </div>
+        </details>
+        <details id="secRumah" class="subcard">
+          <summary>Master Rumah</summary>
+          <div class="stack">
+            <div class="row" style="align-items:flex-end;">
+              <div class="field" style="flex:1 1 220px;">
+                <label class="muted" for="inpRumah">Tambah Label Rumah</label>
+                <input id="inpRumah" class="input" placeholder="mis. A11 atau C1">
+              </div>
+              <button class="btn small" type="button" onclick="addRumah()">Tambah</button>
+              <button class="btn small" type="button" onclick="clearRumah()">Kosongkan Daftar</button>
+              <button class="btn small" type="button" onclick="restoreDefaultRumah()">Pulihkan Default</button>
+            </div>
+            <div id="rumahList" class="chip-list"></div>
+            <p class="muted">Di perangkat kecil, geser tabel ke samping bila konten melebar.</p>
+          </div>
+        </details>
+        <div id="pengaturan-actions-row" class="row">
+          <button class="btn small" type="button" onclick="clearAllDays()">Kosongkan Semua Hari</button>
+          <button class="btn small" type="button" onclick="setView('table')">Mode Tabel</button>
+          <button class="btn small" type="button" onclick="setView('cards')">Mode Kartu</button>
+          <button class="btn small" type="button" onclick="addWorker()">Tambah Baris</button>
+          <button class="btn" type="button" onclick="resetAll()">Reset Semua</button>
+        </div>
+      </div>
+    </details>
 
-    
-      <div id="rumahList" style="margin-top:6px;"></div>
-      <div class="muted" style="margin-top:6px;"> Di mobile, geser horisontal bila tabel melebar.</div></div>
-
-<div class="row" id="pengaturan-actions-row" style="gap:8px; align-items:center; flex-wrap:wrap;">
-<button class="btn" onclick="clearAllDays()">Kosongkan Semua Hari</button>
-<button class="btn small" onclick="setView('table')">Mode Tabel</button>
-<button class="btn small" onclick="setView('cards')">Mode Card</button>
-<button class="btn small" onclick="addWorker()">Tambah Baris</button>
-<button class="btn" onclick="resetAll()">Reset Semua</button>
-
-</div>
-</details><!-- TABLE MODE -->
-    <div id="tableWrap" class="card scroll-x">
-      <div style="min-width:1000px; border:1px solid var(--border); border-radius:12px;">
+    <div id="tableWrap" class="card table-card">
+      <div class="table-container">
         <table id="tbl">
           <thead>
             <tr>
@@ -1092,40 +700,22 @@ tbody td { padding-top: 2px !important; }
       </div>
     </div>
 
-    <!-- CARD MODE -->
     <div id="cardsWrap" class="card" style="display:none;">
-      <div id="cardsBody"></div>
+      <div id="cardsBody" class="stack"></div>
     </div>
 
-    <details class="card collapsible" id="rekap3">
-      <summary><span class="sum-title">Rekap Total Tarif per Rumah</span></summary>
-      <div class="muted"></div>
+    <details class="card" id="rekap3">
+      <summary>Rekap Total Tarif per Rumah</summary>
+      <p class="muted">Rangkuman total hari dan upah per rumah.</p>
       <div id="rekap3Body"></div>
     </details>
-    <details class="card collapsible" id="rekap3day">
-      <summary><span class="sum-title">Rekap per Rumah per Hari</span></summary>
-      <div class="muted"></div>
+
+    <details class="card" id="rekap3day">
+      <summary>Rekap per Rumah per Hari</summary>
+      <p class="muted">Distribusi pekerja per hari untuk setiap rumah.</p>
       <div id="rekap3DayBody"></div>
     </details>
-  </div>
-
-  <!-- Sticky action bar (mobile-friendly running totals) -->
-  <div class="fabbar">
-    <div class="card">
-      <div class="row">
-        <span class="pill">Total Bayar: <span id="pillTotal" class="small">Rp 0</span></span>
-      </div>
-      <div class="row">
-        
-        <button class="btn ghost" onclick="setView(toggleView())">Ganti Mode</button>
-  <div class="search-box no-print">
-        <input id="searchName" type="search" placeholder="Cari nama pekerja…" autocomplete="off" />
-      </div>
-
-      </div>
-    </div>
-  </div>
-
+  </main>
 <script>
   // ===== Defaults =====
   const defaultClassRates = {"Senior":145000,"Tukang":130000,"Kenek":120000};

--- a/index.html
+++ b/index.html
@@ -102,10 +102,12 @@
     document.getElementById('year').textContent = YEAR;
 
     const state = {
-      cursor: '',
-      prev: [],
+      currentCursor: '',
+      nextCursor: '',
+      history: [],
+      cache: new Map(),
       loading: false,
-      lastCursor: null
+      listComplete: false
     };
 
     const tableBody = document.getElementById('listBody');
@@ -149,49 +151,89 @@
       });
     }
 
-    async function loadList() {
-      if (state.loading) return;
-      try {
-        state.loading = true;
+    function resetPagination() {
+      state.currentCursor = '';
+      state.nextCursor = '';
+      state.listComplete = false;
+      state.history = [];
+      state.cache.clear();
+    }
+
+    async function showPage(cursor = '') {
+      if (state.loading) return false;
+      const cached = state.cache.get(cursor);
+      if (!cached) {
         tableBody.innerHTML = '';
         skeleton.classList.remove('hidden');
-        emptyState.classList.add('hidden');
         listInfo.textContent = 'Memuat data...';
-        const { keys = [], cursor, list_complete } = await api.list('ut:snap:', state.cursor, 15);
+      } else {
         skeleton.classList.add('hidden');
-        if (!keys.length && !state.cursor && !cursor) {
+      }
+      emptyState.classList.add('hidden');
+
+      try {
+        state.loading = true;
+        const payload = cached || await api.list('ut:snap:', cursor, 15);
+        if (!cached) {
+          state.cache.set(cursor, payload);
+        }
+        const { keys = [], cursor: nextCursor = '', list_complete } = payload;
+        skeleton.classList.add('hidden');
+
+        if (!keys.length && !cursor && !nextCursor) {
+          tableBody.innerHTML = '';
           emptyState.classList.remove('hidden');
           listInfo.textContent = 'Belum ada snapshot';
           cursorInfo.textContent = '';
-          return;
+          state.currentCursor = '';
+          state.nextCursor = '';
+          state.listComplete = true;
+          document.getElementById('btnPrev').disabled = true;
+          document.getElementById('btnNext').disabled = true;
+          return true;
         }
+
         renderRows(keys.slice(0, 10));
-        cursorInfo.textContent = list_complete ? 'Sudah halaman terakhir' : (cursor ? `Cursor ${cursor.slice(0, 8)}…` : '');
+        state.currentCursor = cursor;
+        state.nextCursor = nextCursor || '';
+        state.listComplete = !!list_complete || (!state.nextCursor && keys.length < 15);
+
+        cursorInfo.textContent = state.listComplete
+          ? 'Sudah halaman terakhir'
+          : (state.nextCursor ? `Cursor ${state.nextCursor.slice(0, 8)}…` : '');
         listInfo.textContent = `${Math.min(keys.length, 10)} dari ${keys.length} entri halaman ini`;
-        state.lastCursor = cursor || null;
-        document.getElementById('btnPrev').disabled = state.prev.length === 0;
-        document.getElementById('btnNext').disabled = list_complete;
+
+        document.getElementById('btnPrev').disabled = state.history.length === 0;
+        document.getElementById('btnNext').disabled = state.listComplete;
+        return true;
       } catch (err) {
         skeleton.classList.add('hidden');
         emptyState.classList.add('hidden');
         showToast(formatError(err), 'error');
         listInfo.textContent = 'Gagal memuat data';
+        return false;
       } finally {
         state.loading = false;
       }
     }
 
-    document.getElementById('btnPrev').addEventListener('click', () => {
-      if (!state.prev.length) return;
-      state.cursor = state.prev.pop() || '';
-      loadList();
+    document.getElementById('btnPrev').addEventListener('click', async () => {
+      if (!state.history.length) return;
+      const target = state.history[state.history.length - 1];
+      const ok = await showPage(target);
+      if (ok) {
+        state.history.pop();
+      }
     });
 
-    document.getElementById('btnNext').addEventListener('click', () => {
-      if (!state.lastCursor) return;
-      state.prev.push(state.cursor);
-      state.cursor = state.lastCursor;
-      loadList();
+    document.getElementById('btnNext').addEventListener('click', async () => {
+      if (state.listComplete && !state.nextCursor) return;
+      const target = state.nextCursor;
+      const previous = state.currentCursor;
+      const ok = await showPage(target);
+      if (ok) {
+        state.history.push(previous);
+      }
     });
 
     document.addEventListener('click', async (event) => {
@@ -203,7 +245,8 @@
         try {
           await api.deleteData(key);
           showToast('Snapshot dihapus', 'success');
-          loadList();
+          resetPagination();
+          await showPage('');
         } catch (err) {
           showToast(formatError(err), 'error');
         }
@@ -224,7 +267,7 @@
     document.getElementById('btnNew').addEventListener('click', openNewForm);
     document.getElementById('ctaNew').addEventListener('click', openNewForm);
 
-    loadList();
+    showPage('');
   </script>
 </body>
 </html>

--- a/rekap.html
+++ b/rekap.html
@@ -128,9 +128,8 @@
       page: 1,
       perPage: 20,
       loading: false,
-      lastCursor: null,
-      cursorStack: [],
-      rawKeys: []
+      rawKeys: [],
+      detailCache: new Map()
     };
 
     const tableBody = document.getElementById('tableBody');
@@ -166,6 +165,12 @@
           safety += 1;
           if (res.list_complete || !cursor || safety > 20) break;
         } while (true);
+
+        const keep = new Set(state.rawKeys.map((entry) => entry.name));
+        Array.from(state.detailCache.keys()).forEach((key) => {
+          if (!keep.has(key)) state.detailCache.delete(key);
+        });
+
         await enrichRecords();
         applyFilter();
         showToast('Data rekap diperbarui', 'success');
@@ -180,9 +185,11 @@
     async function enrichRecords() {
       const records = [];
       const needFetch = [];
+
       state.rawKeys.forEach((entry) => {
         const { name, metadata = {} } = entry;
         const parsed = utils.parseSnapshotKey(name);
+        const cached = state.detailCache.get(name);
         const record = {
           key: name,
           start: metadata.start || parsed.start || '',
@@ -193,30 +200,54 @@
           totalDays: metadata.totalDays ?? null,
           meta: metadata
         };
-        if (record.total == null || record.totalDays == null) {
+
+        if (cached) {
+          Object.assign(record, cached);
+        } else if (record.total == null || record.totalDays == null) {
           needFetch.push(record);
         }
+
         records.push(record);
       });
 
       if (needFetch.length) {
-        for (const item of needFetch) {
-          try {
-            const res = await api.loadData(item.key);
-            const rows = res?.value?.rows || [];
-            item.total = utils.sumRows(rows);
-            item.totalDays = utils.sumDays(rows);
-            item.start = res?.value?.start || item.start;
-            item.end = res?.value?.end || item.end;
-            item.rumah = res?.value?.rumah || item.rumah;
-            item.updatedAt = res?.meta?.updatedAt || item.updatedAt;
-          } catch (err) {
-            console.error('gagal load detail', item.key, err);
-            item.total = item.total ?? 0;
-            item.totalDays = item.totalDays ?? 0;
+        const concurrency = Math.min(4, needFetch.length);
+        let index = 0;
+        const workers = Array.from({ length: concurrency }, () => (async () => {
+          while (index < needFetch.length) {
+            const currentIndex = index++;
+            const item = needFetch[currentIndex];
+            if (!item) break;
+            try {
+              const res = await api.loadData(item.key);
+              const rows = res?.value?.rows || [];
+              const detail = {
+                total: utils.sumRows(rows),
+                totalDays: utils.sumDays(rows),
+                start: res?.value?.start || item.start,
+                end: res?.value?.end || item.end,
+                rumah: res?.value?.rumah || item.rumah,
+                updatedAt: res?.meta?.updatedAt || item.updatedAt
+              };
+              Object.assign(item, detail);
+              state.detailCache.set(item.key, {
+                total: detail.total,
+                totalDays: detail.totalDays,
+                start: detail.start,
+                end: detail.end,
+                rumah: detail.rumah,
+                updatedAt: detail.updatedAt
+              });
+            } catch (err) {
+              console.error('gagal load detail', item.key, err);
+              item.total = item.total ?? 0;
+              item.totalDays = item.totalDays ?? 0;
+            }
           }
-        }
+        })());
+        await Promise.all(workers);
       }
+
       state.all = records.sort((a, b) => {
         const dateA = new Date(a.updatedAt || 0).getTime();
         const dateB = new Date(b.updatedAt || 0).getTime();


### PR DESCRIPTION
## Summary
- redesign the form view with a cleaner layout, consolidated actions, and refreshed totals display while keeping existing data handling intact
- cache snapshot list pages on the dashboard to avoid refetching when paging back and reset pagination after deletes
- reuse detailed snapshot calculations in the rekap view with a small concurrency pool so repeated fetches are faster

## Testing
- no automated tests were run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e380852d2c8333b3a40503cb6bccc5