### PR TITLE
Add in-memory KV fallback for local usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Upah Tukang — Cloudflare Pages (Functions + KV)
 
-UI responsif (HTML/JS + Tailwind CDN) dengan backend **Cloudflare Pages Functions** memakai **KV binding `UPAH_KV`**.
+UI responsif (HTML/JS + Tailwind CDN) dengan backend **Cloudflare Pages Functions** memakai **KV binding `UPAH_KV`** (fallback in-memory otomatis saat binding tidak tersedia untuk pengembangan lokal).
 
 ## Fitur utama
 - Tiga halaman: `index.html`, `form.html`, `rekap.html` — tampilan seragam, mobile-first.

--- a/functions/api/_kv.js
+++ b/functions/api/_kv.js
@@ -1,0 +1,85 @@
+const MEMORY_KEY = Symbol.for('upah.tukang.memoryKV');
+
+function getMemoryNamespace() {
+  const globalSymbols = Object.getOwnPropertySymbols(globalThis);
+  if (!globalSymbols.includes(MEMORY_KEY)) {
+    globalThis[MEMORY_KEY] = new Map();
+  }
+  return globalThis[MEMORY_KEY];
+}
+
+function createMockKV() {
+  const store = getMemoryNamespace();
+
+  return {
+    async list(options = {}) {
+      const { prefix = '', limit = 100, cursor } = options;
+      const allKeys = Array.from(store.keys()).filter((key) => key.startsWith(prefix)).sort();
+
+      let startIndex = 0;
+      if (typeof cursor === 'string' && cursor.trim() !== '') {
+        const parsedCursor = Number.parseInt(cursor, 10);
+        if (Number.isFinite(parsedCursor) && parsedCursor >= 0) {
+          startIndex = parsedCursor;
+        }
+      }
+
+      const slice = allKeys.slice(startIndex, startIndex + limit);
+      const nextIndex = startIndex + slice.length;
+      const hasMore = nextIndex < allKeys.length;
+
+      return {
+        keys: slice.map((name) => {
+          const entry = store.get(name) || {};
+          return {
+            name,
+            expiration: null,
+            metadata: entry.metadata || {}
+          };
+        }),
+        list_complete: !hasMore,
+        cursor: hasMore ? String(nextIndex) : ''
+      };
+    },
+
+    async getWithMetadata(key, options = {}) {
+      if (!store.has(key)) {
+        return null;
+      }
+
+      const entry = store.get(key);
+      let value = entry.value;
+      if (options?.type === 'json') {
+        try {
+          value = JSON.parse(value);
+        } catch (err) {
+          value = null;
+        }
+      }
+
+      return {
+        value,
+        metadata: entry.metadata || {}
+      };
+    },
+
+    async put(key, value, options = {}) {
+      const metadata = options?.metadata || {};
+      store.set(key, { value, metadata });
+    },
+
+    async delete(key) {
+      store.delete(key);
+    }
+  };
+}
+
+export function getKVBinding(env) {
+  if (env && env.UPAH_KV && typeof env.UPAH_KV.list === 'function') {
+    return { kv: env.UPAH_KV, isMock: false };
+  }
+
+  const mockKV = createMockKV();
+  console.warn('UPAH_KV binding tidak ditemukan. Menggunakan penyimpanan sementara dalam memori.');
+  return { kv: mockKV, isMock: true };
+}

--- a/functions/api/list.js
+++ b/functions/api/list.js
@@ -8,6 +8,8 @@ function jsonResponse(data, status = 200) {
   });
 }
 
+import { getKVBinding } from './_kv';
+
 export async function onRequest(context) {
   const { request, env } = context;
   if (request.method.toUpperCase() !== 'GET') {
@@ -24,10 +26,7 @@ export async function onRequest(context) {
   limit = Math.min(Math.max(limit, 1), 200);
 
   try {
-    if (!env.UPAH_KV || typeof env.UPAH_KV.list !== 'function') {
-      throw new Error('Binding UPAH_KV tidak tersedia');
-    }
-
+    const { kv } = getKVBinding(env);
     const listOptions = { limit };
     if (prefix) {
       listOptions.prefix = prefix;
@@ -36,7 +35,7 @@ export async function onRequest(context) {
       listOptions.cursor = cursor;
     }
 
-    const listResult = await env.UPAH_KV.list(listOptions);
+    const listResult = await kv.list(listOptions);
     const keys = (listResult.keys || []).map((entry) => ({
       name: entry.name,
       expiration: entry.expiration || null,

--- a/functions/api/state.js
+++ b/functions/api/state.js
@@ -11,10 +11,13 @@ function jsonResponse(data, status = 200) {
   });
 }
 
+import { getKVBinding } from './_kv';
+
 export async function onRequest(context) {
   const { request, env } = context;
   const url = new URL(request.url);
   const method = request.method.toUpperCase();
+  const { kv } = getKVBinding(env);
 
   try {
     if (method === 'GET') {
@@ -22,7 +25,7 @@ export async function onRequest(context) {
       if (!key) {
         return jsonResponse({ ok: false, error: 'Parameter key wajib' }, 400);
       }
-      const result = await env.UPAH_KV.getWithMetadata(key, { type: 'json' });
+      const result = await kv.getWithMetadata(key, { type: 'json' });
       if (!result || result.value === null || result.value === undefined) {
         return jsonResponse({ ok: false, error: 'Data tidak ditemukan' }, 404);
       }
@@ -59,7 +62,7 @@ export async function onRequest(context) {
       }
       safeMeta.valueSize = stringified.length;
 
-      await env.UPAH_KV.put(key, stringified, { metadata: safeMeta });
+      await kv.put(key, stringified, { metadata: safeMeta });
       return jsonResponse({ ok: true, key, meta: safeMeta });
     }
 
@@ -68,7 +71,7 @@ export async function onRequest(context) {
       if (!key) {
         return jsonResponse({ ok: false, error: 'Parameter key wajib' }, 400);
       }
-      await env.UPAH_KV.delete(key);
+      await kv.delete(key);
       return jsonResponse({ ok: true, key });
     }
 


### PR DESCRIPTION
## Summary
- add a shared helper that provides an in-memory KV mock when the UPAH_KV binding is missing
- update list and state API functions to use the helper so local development no longer fails without the binding
- document the automatic in-memory fallback in the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e386b1f3c883339d129e0a8f92c36b