### PR TITLE
Implement KV-backed snapshot flows

### DIFF
--- a/form.html
+++ b/form.html
@@ -562,7 +562,7 @@
           </div>
         </div>
         <div class="row">
-          <button class="btn" onclick="try{saveAll&&saveAll()}catch(_){ if (typeof save==='function') save('rows', window.rows); else alert('Fungsi simpan tidak tersedia'); }">Simpan</button>
+          <button class="btn" data-testid="form-save" onclick="try{saveAll&&saveAll()}catch(_){ if (typeof save==='function') save('rows', window.rows); else alert('Fungsi simpan tidak tersedia'); }">Simpan</button>
           <button class="btn" onclick="window.print()">Cetak</button>
           <button class="btn" onclick="try{downloadCSV&&downloadCSV()}catch(_){alert('downloadCSV tidak ditemukan')}">Unduh CSV</button>
           <button class="btn" onclick="try{downloadJSON&&downloadJSON()}catch(_){alert('downloadJSON tidak ditemukan')}">Unduh JSON</button>
@@ -820,6 +820,98 @@ const defaultRumahList = baseRumah
   rows.forEach(r=>{ if(r.bonus===undefined) r.bonus=''; });
   let searchName = (localStorage.getItem('upah20_search')||'');
   let viewMode = localStorage.getItem('upah20_viewMode') || (window.innerWidth<=900 ? 'cards' : 'table');
+
+  function deepCopy(value){
+    if (typeof structuredClone === 'function') {
+      try { return structuredClone(value); } catch (_) {}
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  function normaliseRows(nextRows){
+    const base = Array.isArray(nextRows) && nextRows.length ? deepCopy(nextRows) : deepCopy(defaultRows);
+    return base.map((row) => {
+      const clone = { nama: '', kelas: 'Tukang', group: '', rumah: ['', '', '', '', '', '', ''], ket: '', bonus: '', ...row };
+      if (!Array.isArray(clone.rumah)) {
+        clone.rumah = ['', '', '', '', '', '', ''];
+      } else if (clone.rumah.length < 7) {
+        clone.rumah = [...clone.rumah, ...Array(7 - clone.rumah.length).fill('')].slice(0, 7);
+      } else if (clone.rumah.length > 7) {
+        clone.rumah = clone.rumah.slice(0, 7);
+      }
+      if (clone.bonus === undefined) clone.bonus = '';
+      return clone;
+    });
+  }
+
+  window.upahFormBridge = window.upahFormBridge || {};
+  Object.assign(window.upahFormBridge, {
+    getState(){
+      return {
+        rows: deepCopy(rows),
+        classRates: deepCopy(classRates),
+        rumah: Array.isArray(rumah) ? [...rumah] : [],
+        allowance: { threshold: allowanceThreshold, amount: allowanceAmount }
+      };
+    },
+    setRows(next){
+      rows = normaliseRows(next);
+      save('rows', rows);
+      rerender();
+    },
+    setClassRates(next){
+      const safe = deepCopy(defaultClassRates);
+      Object.assign(safe, next || {});
+      classRates = safe;
+      save('classRates', classRates);
+      bootRatesUI();
+      rerender();
+    },
+    setRumah(list){
+      rumah = Array.isArray(list) ? list.filter((item) => item != null && String(item).trim().length).map((item) => String(item)) : [];
+      save('rumah', rumah);
+      renderRumah();
+      rerender();
+    },
+    setAllowance(values){
+      if (!values || typeof values !== 'object') return;
+      if (values.threshold !== undefined) {
+        allowanceThreshold = Number(values.threshold) || 0;
+        localStorage.setItem('upah20_beras_threshold', String(allowanceThreshold));
+      }
+      if (values.amount !== undefined) {
+        allowanceAmount = Number(values.amount) || 0;
+        localStorage.setItem('upah20_beras_amount', String(allowanceAmount));
+      }
+      bootBerasUI();
+      rerender();
+    },
+    setPeriod(period){
+      const startEl = document.getElementById('periodStart');
+      const endEl = document.getElementById('periodEnd');
+      if (period && typeof period === 'object') {
+        if (startEl && period.start !== undefined) {
+          startEl.value = period.start || '';
+          localStorage.setItem('upah20_periodStart', period.start || '');
+        }
+        if (endEl && period.end !== undefined) {
+          endEl.value = period.end || '';
+          localStorage.setItem('upah20_periodEnd', period.end || '');
+        }
+      }
+    },
+    resetToDefault(){
+      try { restoreDefaultRows(); } catch (_) {}
+      try { restoreDefaultRates(); } catch (_) {}
+      try { restoreDefaultRumah(); } catch (_) {}
+      allowanceThreshold = 3.9;
+      allowanceAmount = 20000;
+      localStorage.setItem('upah20_beras_threshold', String(allowanceThreshold));
+      localStorage.setItem('upah20_beras_amount', String(allowanceAmount));
+      bootBerasUI();
+      rerender();
+    }
+  });
 
   // ===== UI logic =====
   function restoreDefaultRates(){ classRates = structuredClone(defaultClassRates); bootRatesUI(); rerender(); }
@@ -1955,6 +2047,295 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch(e){ console.warn('Restore snapshot failed', e); }
   })();
 })();
+</script>
+
+<script type="module">
+  import { ensureApiClient, buildSnapshotKey, summarizeRows, showToast, formatError } from '/assets/js/upah-core.js';
+
+  const api = ensureApiClient();
+  const params = new URLSearchParams(window.location.search);
+  const bridge = window.upahFormBridge || {};
+
+  const state = {
+    currentKey: params.get('key') || '',
+    isSaving: false,
+    lastMeta: null
+  };
+
+  const STORAGE_KEYS = {
+    rows: 'upah20_rows',
+    rates: 'upah20_classRates',
+    rumah: 'upah20_rumah',
+    periodStart: 'upah20_periodStart',
+    periodEnd: 'upah20_periodEnd',
+    allowanceThreshold: 'upah20_beras_threshold',
+    allowanceAmount: 'upah20_beras_amount',
+    lastKey: 'upah20_last_key'
+  };
+
+  function readLocalJSON(key, fallback) {
+    try {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) return fallback;
+      return JSON.parse(raw);
+    } catch (err) {
+      console.warn('readLocalJSON fallback', key, err);
+      return fallback;
+    }
+  }
+
+  function readWorkingState() {
+    if (bridge && typeof bridge.getState === 'function') {
+      try {
+        return bridge.getState();
+      } catch (err) {
+        console.warn('bridge.getState gagal', err);
+      }
+    }
+    return {
+      rows: readLocalJSON(STORAGE_KEYS.rows, []),
+      classRates: readLocalJSON(STORAGE_KEYS.rates, {}),
+      rumah: readLocalJSON(STORAGE_KEYS.rumah, []),
+      allowance: {
+        threshold: Number(window.localStorage.getItem(STORAGE_KEYS.allowanceThreshold) || '0'),
+        amount: Number(window.localStorage.getItem(STORAGE_KEYS.allowanceAmount) || '0')
+      }
+    };
+  }
+
+  function readPeriod() {
+    const startEl = document.getElementById('periodStart');
+    const endEl = document.getElementById('periodEnd');
+    const start = startEl?.value || window.localStorage.getItem(STORAGE_KEYS.periodStart) || '';
+    const end = endEl?.value || window.localStorage.getItem(STORAGE_KEYS.periodEnd) || '';
+    return { start, end };
+  }
+
+  function deriveRumahLabel(rumahList = [], rows = []) {
+    const list = Array.isArray(rumahList) ? rumahList.filter((item) => item != null && String(item).trim().length) : [];
+    if (list.length === 1) {
+      return String(list[0]);
+    }
+    const assigned = [];
+    rows.forEach((row) => {
+      (Array.isArray(row?.rumah) ? row.rumah : []).forEach((slot) => {
+        const raw = String(slot || '').trim();
+        if (!raw) return;
+        if (raw === '1/2 Lain') return;
+        if (/^1\/2\b/i.test(raw)) {
+          const cleaned = raw.replace(/^1\/2\s*/i, '').trim();
+          if (cleaned) assigned.push(cleaned);
+          return;
+        }
+        assigned.push(raw);
+      });
+    });
+    if (assigned.length) {
+      return assigned[0];
+    }
+    if (list.length) {
+      return String(list[0]);
+    }
+    return '';
+  }
+
+  function setSaving(flag) {
+    state.isSaving = flag;
+    const btn = document.querySelector('[data-testid="form-save"]');
+    if (btn) {
+      btn.disabled = !!flag;
+      if (flag) {
+        btn.setAttribute('aria-busy', 'true');
+      } else {
+        btn.removeAttribute('aria-busy');
+      }
+    }
+  }
+
+  function updateUrlWithKey(key) {
+    const url = new URL(window.location.href);
+    if (key) {
+      url.searchParams.set('key', key);
+      url.searchParams.delete('new');
+    } else {
+      url.searchParams.delete('key');
+    }
+    window.history.replaceState({}, document.title, `${url.pathname}${url.search}${url.hash}`);
+  }
+
+  async function persistSnapshot() {
+    if (state.isSaving) return;
+    setSaving(true);
+    try {
+      const { rows, classRates, rumah, allowance } = readWorkingState();
+      const period = readPeriod();
+      const rumahLabel = deriveRumahLabel(rumah, rows);
+      const allowanceThreshold = Number(allowance?.threshold ?? window.localStorage.getItem(STORAGE_KEYS.allowanceThreshold) ?? 0) || 0;
+      const allowanceAmount = Number(allowance?.amount ?? window.localStorage.getItem(STORAGE_KEYS.allowanceAmount) ?? 0) || 0;
+      const summary = summarizeRows(rows, { classRates, allowanceThreshold, allowanceAmount });
+      const nowISO = new Date().toISOString();
+
+      const payload = {
+        version: 1,
+        start: period.start || '',
+        end: period.end || '',
+        rumah: rumahLabel || '',
+        rumahList: Array.isArray(rumah) ? [...rumah] : [],
+        classRates,
+        allowance: { threshold: allowanceThreshold, amount: allowanceAmount },
+        rows,
+        summary,
+        updatedAt: nowISO
+      };
+
+      const meta = {
+        start: payload.start || null,
+        end: payload.end || null,
+        rumah: payload.rumah || null,
+        total: summary.total,
+        totalDays: summary.totalDays,
+        updatedAt: nowISO
+      };
+
+      let key = state.currentKey;
+      if (!key) {
+        key = buildSnapshotKey({ start: payload.start, end: payload.end, rumah: payload.rumah, uuid: params.get('new') || undefined });
+      }
+
+      await api.saveSnapshot(key, payload, meta);
+      state.currentKey = key;
+      state.lastMeta = meta;
+      window.localStorage.setItem(STORAGE_KEYS.lastKey, key);
+      updateUrlWithKey(key);
+      if (typeof showToast === 'function') {
+        showToast('Snapshot tersimpan ke Cloudflare KV', 'success');
+      }
+      return key;
+    } catch (err) {
+      console.error('persistSnapshot gagal', err);
+      if (typeof showToast === 'function') {
+        showToast(formatError(err), 'error');
+      } else {
+        alert(formatError(err));
+      }
+      throw err;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function restoreSnapshot(key) {
+    if (!key) return;
+    setSaving(true);
+    try {
+      const res = await api.loadSnapshot(key);
+      const value = res?.value || {};
+      const rows = value.rows || value.data?.rows || [];
+      const classRates = value.classRates || value.rates || {};
+      const rumahList = value.rumahList || value.rumah || [];
+      const allowance = value.allowance || { threshold: value.allowanceThreshold, amount: value.allowanceAmount };
+      const period = {
+        start: value.start || value.periodStart || '',
+        end: value.end || value.periodEnd || ''
+      };
+
+      if (typeof bridge.setRows === 'function') bridge.setRows(rows);
+      if (typeof bridge.setClassRates === 'function') bridge.setClassRates(classRates);
+      if (typeof bridge.setRumah === 'function') bridge.setRumah(rumahList);
+      if (typeof bridge.setAllowance === 'function') bridge.setAllowance({
+        threshold: allowance?.threshold ?? allowance?.thr,
+        amount: allowance?.amount ?? allowance?.amt
+      });
+      if (typeof bridge.setPeriod === 'function') bridge.setPeriod(period);
+
+      state.currentKey = key;
+      window.localStorage.setItem(STORAGE_KEYS.lastKey, key);
+      updateUrlWithKey(key);
+      if (typeof showToast === 'function') {
+        showToast('Snapshot dimuat dari Cloudflare KV', 'success');
+      }
+    } catch (err) {
+      console.error('restoreSnapshot gagal', err);
+      if (typeof showToast === 'function') {
+        showToast(formatError(err), 'error');
+      } else {
+        alert(formatError(err));
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function prepareNewForm() {
+    state.currentKey = '';
+    try {
+      window.localStorage.removeItem(STORAGE_KEYS.lastKey);
+      if (typeof bridge.resetToDefault === 'function') {
+        bridge.resetToDefault();
+      }
+      if (typeof bridge.setPeriod === 'function') {
+        bridge.setPeriod({ start: '', end: '' });
+      }
+      updateUrlWithKey('');
+    } catch (err) {
+      console.warn('prepareNewForm warning', err);
+    }
+  }
+
+  const originalSaveAll = window.saveAll;
+  window.saveAll = async function patchedSaveAll(...args) {
+    await persistSnapshot();
+    if (typeof originalSaveAll === 'function') {
+      try {
+        const result = originalSaveAll.apply(this, args);
+        if (result && typeof result.then === 'function') {
+          return await result;
+        }
+        return result;
+      } catch (err) {
+        console.warn('original saveAll error', err);
+        throw err;
+      }
+    }
+    return undefined;
+  };
+
+  function init() {
+    const saveBtn = document.querySelector('[data-testid="form-save"]');
+    if (saveBtn) {
+      saveBtn.type = 'button';
+    }
+
+    if (params.has('new')) {
+      prepareNewForm();
+    } else if (!state.currentKey) {
+      const lastKey = window.localStorage.getItem(STORAGE_KEYS.lastKey);
+      if (lastKey) {
+        state.currentKey = lastKey;
+      }
+    }
+
+    if (state.currentKey) {
+      restoreSnapshot(state.currentKey);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+
+  window.addEventListener('beforeunload', () => {
+    if (state.isSaving) {
+      setSaving(false);
+    }
+  });
+
+  window.upahFormController = {
+    save: persistSnapshot,
+    restore: restoreSnapshot
+  };
 </script>
 
 </body>

--- a/functions/api/state.js
+++ b/functions/api/state.js
@@ -53,12 +53,25 @@ export async function onRequest(context) {
       }
 
       const safeMeta = {};
+      const nowISO = new Date().toISOString();
       if (meta && typeof meta === 'object') {
         for (const keyName of ALLOWED_META_KEYS) {
           if (meta[keyName] !== undefined) {
             safeMeta[keyName] = meta[keyName];
           }
         }
+      }
+      if (!safeMeta.updatedAt) {
+        safeMeta.updatedAt = nowISO;
+      }
+      if (!safeMeta.start && typeof value === 'object' && value) {
+        safeMeta.start = value.start || value.periodStart || null;
+      }
+      if (!safeMeta.end && typeof value === 'object' && value) {
+        safeMeta.end = value.end || value.periodEnd || null;
+      }
+      if (!safeMeta.rumah && typeof value === 'object' && value) {
+        safeMeta.rumah = value.rumah || value.rumahUtama || null;
       }
       safeMeta.valueSize = stringified.length;
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
       <nav class="flex items-center gap-2 text-sm">
         <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="/rekap.html">Rekap</a>
         <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="/form.html">Isi Form</a>
-        <button id="btnNew" class="rounded-xl bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
+        <button id="btnNew" data-testid="dashboard-open-new" class="rounded-xl bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
       </nav>
     </div>
   </header>
@@ -31,7 +31,7 @@
         <h2 class="text-base font-semibold text-slate-900">Mulai Form Baru</h2>
         <p class="mt-2 text-sm text-slate-500">Siapkan draft kosong dengan periode 7 hari ke depan. Data tersimpan otomatis di Cloudflare KV.</p>
         <div class="mt-4 flex flex-wrap gap-2">
-          <button id="ctaNew" class="rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
+          <button id="ctaNew" data-testid="dashboard-cta-new" class="rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
           <a href="/form.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Lanjutkan Draft</a>
         </div>
       </article>
@@ -98,6 +98,8 @@
 
     const api = ensureApiClient();
 
+    const NEW_COUNTER_KEY = 'upahTukang:newCounter';
+
     const YEAR = new Date().getFullYear();
     document.getElementById('year').textContent = YEAR;
 
@@ -132,6 +134,7 @@
         const info = buildKeyInfo(name, metadata || {});
         const tr = document.createElement('tr');
         tr.className = 'transition hover:bg-slate-50';
+        tr.dataset.testid = 'snapshot-row';
         tr.innerHTML = `
           <td class="py-3 pr-4 align-top">
             <div class="font-medium text-slate-800">${info.periode}</div>
@@ -143,7 +146,7 @@
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
               <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="/form.html?key=${encodeURIComponent(name)}">Buka</a>
-              <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-key="${name}">Hapus</button>
+              <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="dashboard-delete" data-key="${name}">Hapus</button>
             </div>
           </td>
         `;
@@ -173,7 +176,7 @@
 
       try {
         state.loading = true;
-        const payload = cached || await api.list('ut:snap:', cursor, 15);
+        const payload = cached || await api.listSnapshots('ut:snap:', cursor, 15);
         if (!cached) {
           state.cache.set(cursor, payload);
         }
@@ -243,7 +246,7 @@
         const confirmed = window.confirm('Hapus snapshot ini? Data tidak dapat dikembalikan.');
         if (!confirmed) return;
         try {
-          await api.deleteData(key);
+          await api.deleteKey(key);
           showToast('Snapshot dihapus', 'success');
           resetPagination();
           await showPage('');
@@ -253,14 +256,22 @@
       }
     });
 
+    function nextNewIndex() {
+      try {
+        const current = Number(window.localStorage.getItem(NEW_COUNTER_KEY) || '0');
+        const next = Number.isFinite(current) ? current + 1 : 1;
+        window.localStorage.setItem(NEW_COUNTER_KEY, String(next));
+        return next;
+      } catch (err) {
+        console.warn('gagal membaca counter new form', err);
+        return Math.floor(Date.now() / 1000);
+      }
+    }
+
     function openNewForm() {
-      const start = utils.todayISO();
-      const end = utils.plusDaysISO(start, 6);
-      const id = utils.uuid();
+      const index = nextNewIndex();
       const url = new URL('/form.html', window.location.origin);
-      url.searchParams.set('new', id);
-      url.searchParams.set('start', start);
-      url.searchParams.set('end', end);
+      url.searchParams.set('new', String(index));
       window.location.href = url.toString();
     }
 

--- a/rekap.html
+++ b/rekap.html
@@ -21,8 +21,8 @@
         </div>
       </div>
       <div class="flex flex-wrap items-center gap-2 text-sm">
-        <button id="btnExportXLSX" class="rounded-xl border border-slate-200 px-3 py-2 font-medium text-slate-600 hover:border-slate-300">Export XLSX</button>
-        <button id="btnExportCSV" class="rounded-xl border border-slate-200 px-3 py-2 font-medium text-slate-600 hover:border-slate-300">Export CSV</button>
+        <button id="btnExportXLSX" data-testid="rekap-export-xlsx" class="rounded-xl border border-slate-200 px-3 py-2 font-medium text-slate-600 hover:border-slate-300">Export XLSX</button>
+        <button id="btnExportCSV" data-testid="rekap-export-csv" class="rounded-xl border border-slate-200 px-3 py-2 font-medium text-slate-600 hover:border-slate-300">Export CSV</button>
       </div>
     </div>
   </header>
@@ -93,7 +93,7 @@
               <th class="py-2 pl-4 font-medium text-right">Aksi</th>
             </tr>
           </thead>
-          <tbody id="tableBody" class="divide-y divide-slate-100"></tbody>
+          <tbody id="tableBody" class="divide-y divide-slate-100" data-testid="rekap-table-body"></tbody>
         </table>
       </div>
       <div class="mt-4 flex flex-wrap items-center justify-between gap-3 text-sm">
@@ -118,6 +118,8 @@
     import { utils, showToast, formatError, ensureApiClient } from '/assets/js/upah-core.js';
 
     const api = ensureApiClient();
+
+    const AUTO_REFRESH_MS = 15000;
 
     const YEAR = new Date().getFullYear();
     document.getElementById('year').textContent = YEAR;
@@ -147,7 +149,7 @@
       search: document.getElementById('filterSearch')
     };
 
-    async function fetchAll() {
+    async function fetchAll({ silent = false } = {}) {
       if (state.loading) return;
       state.loading = true;
       state.rawKeys = [];
@@ -159,7 +161,7 @@
       let safety = 0;
       try {
         do {
-          const res = await api.list('ut:snap:', cursor, 100);
+          const res = await api.listSnapshots('ut:snap:', cursor, 100);
           state.rawKeys.push(...(res.keys || []));
           cursor = res.cursor || '';
           safety += 1;
@@ -173,7 +175,9 @@
 
         await enrichRecords();
         applyFilter();
-        showToast('Data rekap diperbarui', 'success');
+        if (!silent) {
+          showToast('Data rekap diperbarui', 'success');
+        }
       } catch (err) {
         showToast(formatError(err), 'error');
         tableSkeleton.classList.add('hidden');
@@ -302,6 +306,7 @@
         const updated = item.updatedAt ? new Date(item.updatedAt).toLocaleString('id-ID') : '—';
         const tr = document.createElement('tr');
         tr.className = 'transition hover:bg-slate-50';
+        tr.dataset.testid = 'rekap-row';
         tr.innerHTML = `
           <td class="py-3 pr-4 align-top">
             <div class="font-medium text-slate-800">${periode}</div>
@@ -314,7 +319,7 @@
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
               <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="/form.html?key=${encodeURIComponent(item.key)}">Buka</a>
-              <button class="btnDelete rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-key="${item.key}">Hapus</button>
+              <button class="btnDelete rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="rekap-delete" data-key="${item.key}">Hapus</button>
             </div>
           </td>
         `;
@@ -377,7 +382,7 @@
         const key = event.target.getAttribute('data-key');
         if (!window.confirm('Hapus snapshot ini?')) return;
         try {
-          await api.deleteData(key);
+          await api.deleteKey(key);
           showToast('Snapshot dihapus', 'success');
           state.rawKeys = state.rawKeys.filter((entry) => entry.name !== key);
           state.all = state.all.filter((entry) => entry.key !== key);
@@ -446,7 +451,13 @@
       showToast('File CSV dibuat', 'success');
     });
 
-    fetchAll();
+    fetchAll({ silent: true });
+
+    setInterval(() => {
+      if (document.hidden) return;
+      if (state.loading) return;
+      fetchAll({ silent: true });
+    }, AUTO_REFRESH_MS);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extend the shared API client with snapshot helpers for key generation and totals
- connect the form to Cloudflare KV for saving/loading snapshots while honouring the ?new flow
- refresh dashboard and rekap pages to list, delete, and export KV-backed snapshots reliably

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68e389fd390083339b5076abd22435d3