### PR TITLE
Fix snapshot links and tighten form layout

### DIFF
--- a/form.html
+++ b/form.html
@@ -41,6 +41,7 @@
       background: var(--bg);
       color: var(--text);
       font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      font-size: clamp(0.9rem, 0.85rem + 0.2vw, 1rem);
       line-height: 1.5;
     }
     a { color: inherit; text-decoration: none; }
@@ -78,8 +79,9 @@
     }
     #appTitle {
       margin: 0;
-      font-size: 1.4rem;
+      font-size: clamp(1.1rem, 1rem + 0.4vw, 1.35rem);
       font-weight: 700;
+      line-height: 1.2;
     }
     .nav-links {
       display: flex;
@@ -132,7 +134,7 @@
     }
     .section-header h2 {
       margin: 0;
-      font-size: 1.05rem;
+      font-size: clamp(0.95rem, 0.9rem + 0.2vw, 1.05rem);
       font-weight: 600;
     }
     .field {
@@ -175,7 +177,7 @@
       background: var(--surface);
       padding: 0.55rem 1rem;
       font-weight: 600;
-      font-size: 0.9rem;
+      font-size: 0.85rem;
       transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
     }
     .btn:hover {
@@ -305,17 +307,19 @@
       min-width: 1024px;
       border-collapse: separate;
       border-spacing: 0;
+      font-size: clamp(0.75rem, 0.72rem + 0.2vw, 0.9rem);
     }
     .table-card th,
     .table-card td {
       padding: 0.65rem 0.75rem;
       border-bottom: 1px solid rgba(148,163,184,0.22);
       vertical-align: top;
+      line-height: 1.35;
     }
     .table-card thead th {
-      font-size: 0.7rem;
+      font-size: clamp(0.6rem, 0.55rem + 0.15vw, 0.7rem);
       text-transform: uppercase;
-      letter-spacing: 0.12em;
+      letter-spacing: 0.1em;
       color: var(--text-muted);
       background: var(--surface-muted);
       font-weight: 600;
@@ -351,7 +355,7 @@
       flex-wrap: wrap;
       align-items: center;
     }
-    .name { font-weight: 700; font-size: 1rem; }
+    .worker-card .name { font-weight: 700; font-size: 0.95rem; }
     .daygrid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
@@ -365,6 +369,7 @@
       display: flex;
       flex-direction: column;
       gap: 0.4rem;
+      font-size: 0.9rem;
     }
     .kv { display: flex; flex-wrap: wrap; gap: 0.6rem; margin-top: 0.5rem; }
     .cellstack { display: flex; flex-direction: column; align-items: flex-end; gap: 0.15rem; }
@@ -516,8 +521,8 @@
         <h1 id="appTitle">Kalkulator Upah 7 Hari</h1>
       </div>
       <nav class="nav-links">
-        <a href="/index.html">Dasbor</a>
-        <a href="/rekap.html">Rekap</a>
+        <a href="index.html">Dasbor</a>
+        <a href="rekap.html">Rekap</a>
       </nav>
     </div>
   </header>
@@ -2050,7 +2055,7 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 
 <script type="module">
-  import { ensureApiClient, buildSnapshotKey, summarizeRows, showToast, formatError } from '/assets/js/upah-core.js';
+  import { ensureApiClient, buildSnapshotKey, summarizeRows, showToast, formatError } from './assets/js/upah-core.js';
 
   const api = ensureApiClient();
   const params = new URLSearchParams(window.location.search);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/css/extra.css">
+  <link rel="stylesheet" href="assets/css/extra.css">
 </head>
 <body class="bg-slate-50 text-slate-800">
   <header class="sticky top-0 z-20 border-b bg-white/90 backdrop-blur">
@@ -18,8 +18,8 @@
         <h1 class="text-lg font-semibold">Dasbor</h1>
       </div>
       <nav class="flex items-center gap-2 text-sm">
-        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="/rekap.html">Rekap</a>
-        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="/form.html">Isi Form</a>
+        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="rekap.html">Rekap</a>
+        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="form.html">Isi Form</a>
         <button id="btnNew" data-testid="dashboard-open-new" class="rounded-xl bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
       </nav>
     </div>
@@ -32,14 +32,14 @@
         <p class="mt-2 text-sm text-slate-500">Siapkan draft kosong dengan periode 7 hari ke depan. Data tersimpan otomatis di Cloudflare KV.</p>
         <div class="mt-4 flex flex-wrap gap-2">
           <button id="ctaNew" data-testid="dashboard-cta-new" class="rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
-          <a href="/form.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Lanjutkan Draft</a>
+          <a href="form.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Lanjutkan Draft</a>
         </div>
       </article>
       <article class="rounded-2xl bg-white p-6 shadow-sm">
         <h2 class="text-base font-semibold text-slate-900">Rekap & Ekspor</h2>
         <p class="mt-2 text-sm text-slate-500">Pantau seluruh snapshot, filter sesuai kebutuhan, dan ekspor ke CSV/XLSX untuk arsip.</p>
         <div class="mt-4 flex flex-wrap gap-2">
-          <a href="/rekap.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Buka Rekap</a>
+          <a href="rekap.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Buka Rekap</a>
           <span class="badge">Autosave aktif</span>
         </div>
       </article>
@@ -94,7 +94,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { utils, showToast, formatError, ensureApiClient } from '/assets/js/upah-core.js';
+    import { utils, showToast, formatError, ensureApiClient } from './assets/js/upah-core.js';
 
     const api = ensureApiClient();
 
@@ -145,7 +145,7 @@
           <td class="py-3 pr-4 align-top text-slate-600">${info.updatedAt}</td>
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
-              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="/form.html?key=${encodeURIComponent(name)}">Buka</a>
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form.html?key=${encodeURIComponent(name)}">Buka</a>
               <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="dashboard-delete" data-key="${name}">Hapus</button>
             </div>
           </td>
@@ -270,7 +270,7 @@
 
     function openNewForm() {
       const index = nextNewIndex();
-      const url = new URL('/form.html', window.location.origin);
+      const url = new URL('form.html', window.location.href);
       url.searchParams.set('new', String(index));
       window.location.href = url.toString();
     }

--- a/rekap.html
+++ b/rekap.html
@@ -8,13 +8,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/assets/css/extra.css">
+  <link rel="stylesheet" href="assets/css/extra.css">
 </head>
 <body class="bg-slate-50 text-slate-800">
   <header class="sticky top-0 z-20 border-b bg-white/90 backdrop-blur">
     <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-3">
       <div class="flex items-center gap-3">
-        <a href="/index.html" class="rounded-xl border border-transparent px-3 py-2 text-sm text-slate-500 transition hover:border-slate-200 hover:text-slate-700">&larr; Beranda</a>
+        <a href="index.html" class="rounded-xl border border-transparent px-3 py-2 text-sm text-slate-500 transition hover:border-slate-200 hover:text-slate-700">&larr; Beranda</a>
         <div>
           <p class="text-xs uppercase tracking-wide text-slate-400">Upah Tukang</p>
           <h1 class="text-lg font-semibold">Rekap Snapshot</h1>
@@ -115,7 +115,7 @@
 
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
   <script type="module">
-    import { utils, showToast, formatError, ensureApiClient } from '/assets/js/upah-core.js';
+    import { utils, showToast, formatError, ensureApiClient } from './assets/js/upah-core.js';
 
     const api = ensureApiClient();
 
@@ -318,7 +318,7 @@
           <td class="py-3 pr-4 align-top text-slate-600">${updated}</td>
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
-              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="/form.html?key=${encodeURIComponent(item.key)}">Buka</a>
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form.html?key=${encodeURIComponent(item.key)}">Buka</a>
               <button class="btnDelete rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="rekap-delete" data-key="${item.key}">Hapus</button>
             </div>
           </td>


### PR DESCRIPTION
## Summary
- switch navigation links and module imports to relative paths so snapshot links stay valid across browsers
- tweak the form layout typography to reduce overlap on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e38e7730f08333acaaac216a490f48