### PR TITLE
Make mobile totals and controls float at top

### DIFF
--- a/form.html
+++ b/form.html
@@ -247,6 +247,21 @@
       flex-direction: column;
       gap: 0.75rem;
     }
+    .totals-floating {
+      display: grid;
+      grid-template-columns: minmax(0, 0.9fr) minmax(220px, 1.1fr) auto;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .totals-floating .total-chip {
+      height: 100%;
+    }
+    .totals-floating .totals-actions {
+      justify-content: flex-end;
+    }
+    .totals-floating .totals-actions .btn {
+      white-space: nowrap;
+    }
     .totals-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
@@ -603,12 +618,25 @@
       .section-header { flex-direction: column; align-items: stretch; }
       .totals-panel {
         position: sticky;
-        bottom: 1rem;
-        z-index: 30;
-        margin: 0 -0.5rem;
-        backdrop-filter: blur(12px);
-        box-shadow: 0 -12px 32px rgba(15,23,42,0.18);
+        top: calc(0.75rem + var(--safe-area-inset-top, 0px));
+        z-index: 35;
+        margin: -1.35rem -1.35rem 0;
+        padding: 1rem 1.1rem 1.15rem;
+        backdrop-filter: blur(14px);
+        box-shadow: 0 16px 32px rgba(15,23,42,0.22);
+        border: 1px solid rgba(148,163,184,0.32);
+        border-radius: calc(var(--radius-lg) + 6px);
       }
+      .totals-floating {
+        grid-template-columns: 1fr;
+      }
+      .totals-floating .totals-actions {
+        justify-content: stretch;
+      }
+      .totals-floating .totals-actions .btn {
+        width: 100%;
+      }
+      .search-field { width: 100%; }
     }
   </style>
 </head>
@@ -632,10 +660,6 @@
         <div>
           <h2>Periode &amp; Aksi</h2>
           <p class="muted">Setel rentang tanggal kerja lalu simpan atau ekspor data.</p>
-        </div>
-        <div class="field search-field">
-          <label class="muted" for="searchName">Cari Pekerja</label>
-          <input id="searchName" type="search" class="input" placeholder="Cari nama pekerja…" autocomplete="off">
         </div>
       </div>
       <div id="mainActionsFixed" class="stack action-shell">
@@ -675,6 +699,19 @@
         </div>
       </div>
       <div class="totals-panel no-print">
+        <div class="totals-floating">
+          <div class="total-chip highlight">
+            <span class="label">Total Bayar</span>
+            <span id="pillTotal" class="value">Rp 0</span>
+          </div>
+          <div class="field search-field">
+            <label class="muted" for="searchName">Cari Pekerja</label>
+            <input id="searchName" type="search" class="input" placeholder="Cari nama pekerja…" autocomplete="off">
+          </div>
+          <div class="totals-actions">
+            <button class="btn ghost" onclick="setView(toggleView())">Ganti Mode</button>
+          </div>
+        </div>
         <div class="totals-grid">
           <div class="total-chip">
             <span class="label">Total Hari</span>
@@ -688,13 +725,6 @@
             <span class="label">Uang Beras</span>
             <span id="pillBeras" class="value">Rp 0</span>
           </div>
-          <div class="total-chip highlight">
-            <span class="label">Total Bayar</span>
-            <span id="pillTotal" class="value">Rp 0</span>
-          </div>
-        </div>
-        <div class="totals-actions">
-          <button class="btn ghost" onclick="setView(toggleView())">Ganti Mode</button>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- move the search field and view mode toggle into the totals panel and highlight the Total Bayar chip
- add responsive layout styles so on mobile the toolbar floats at the top with full-width controls and on desktop it stays inline

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e71480b2c483339bdf8d474fd05677