### PR TITLE
Ensure mobile totals toolbar stays pinned

### DIFF
--- a/form.html
+++ b/form.html
@@ -25,6 +25,7 @@
       --radius-lg: 20px;
       --radius-md: 14px;
       --radius-sm: 10px;
+      --app-header-offset: 72px;
     }
     @media (prefers-color-scheme: dark) {
       :root {
@@ -238,14 +239,29 @@
     }
     .cal-btn svg { width: 18px; height: 18px; color: var(--text-muted); }
     .search-field { min-width: 220px; }
-    .totals-panel {
-      border-radius: var(--radius-lg);
-      border: 1px solid rgba(148,163,184,0.24);
-      background: var(--surface-muted);
-      padding: 1.1rem;
-      display: flex;
+      .totals-panel {
+        border-radius: var(--radius-lg);
+        border: 1px solid rgba(148,163,184,0.24);
+        background: var(--surface-muted);
+        padding: 1.1rem;
+        display: flex;
       flex-direction: column;
       gap: 0.75rem;
+    }
+    .totals-floating {
+      display: grid;
+      grid-template-columns: minmax(0, 0.9fr) minmax(220px, 1.1fr) auto;
+      align-items: center;
+      gap: 0.75rem;
+    }
+    .totals-floating .total-chip {
+      height: 100%;
+    }
+    .totals-floating .totals-actions {
+      justify-content: flex-end;
+    }
+    .totals-floating .totals-actions .btn {
+      white-space: nowrap;
     }
     .totals-grid {
       display: grid;
@@ -603,12 +619,25 @@
       .section-header { flex-direction: column; align-items: stretch; }
       .totals-panel {
         position: sticky;
-        bottom: 1rem;
-        z-index: 30;
-        margin: 0 -0.5rem;
-        backdrop-filter: blur(12px);
-        box-shadow: 0 -12px 32px rgba(15,23,42,0.18);
+        top: calc(var(--app-header-offset, 0px) + 0.75rem + var(--safe-area-inset-top, 0px));
+        z-index: 35;
+        margin: -1.35rem -1.35rem 0;
+        padding: 1rem 1.1rem 1.15rem;
+        backdrop-filter: blur(14px);
+        box-shadow: 0 16px 32px rgba(15,23,42,0.22);
+        border: 1px solid rgba(148,163,184,0.32);
+        border-radius: calc(var(--radius-lg) + 6px);
       }
+      .totals-floating {
+        grid-template-columns: 1fr;
+      }
+      .totals-floating .totals-actions {
+        justify-content: stretch;
+      }
+      .totals-floating .totals-actions .btn {
+        width: 100%;
+      }
+      .search-field { width: 100%; }
     }
   </style>
 </head>
@@ -632,10 +661,6 @@
         <div>
           <h2>Periode &amp; Aksi</h2>
           <p class="muted">Setel rentang tanggal kerja lalu simpan atau ekspor data.</p>
-        </div>
-        <div class="field search-field">
-          <label class="muted" for="searchName">Cari Pekerja</label>
-          <input id="searchName" type="search" class="input" placeholder="Cari nama pekerja…" autocomplete="off">
         </div>
       </div>
       <div id="mainActionsFixed" class="stack action-shell">
@@ -675,6 +700,19 @@
         </div>
       </div>
       <div class="totals-panel no-print">
+        <div class="totals-floating">
+          <div class="total-chip highlight">
+            <span class="label">Total Bayar</span>
+            <span id="pillTotal" class="value">Rp 0</span>
+          </div>
+          <div class="field search-field">
+            <label class="muted" for="searchName">Cari Pekerja</label>
+            <input id="searchName" type="search" class="input" placeholder="Cari nama pekerja…" autocomplete="off">
+          </div>
+          <div class="totals-actions">
+            <button class="btn ghost" onclick="setView(toggleView())">Ganti Mode</button>
+          </div>
+        </div>
         <div class="totals-grid">
           <div class="total-chip">
             <span class="label">Total Hari</span>
@@ -688,13 +726,6 @@
             <span class="label">Uang Beras</span>
             <span id="pillBeras" class="value">Rp 0</span>
           </div>
-          <div class="total-chip highlight">
-            <span class="label">Total Bayar</span>
-            <span id="pillTotal" class="value">Rp 0</span>
-          </div>
-        </div>
-        <div class="totals-actions">
-          <button class="btn ghost" onclick="setView(toggleView())">Ganti Mode</button>
         </div>
       </div>
     </section>
@@ -1927,6 +1958,24 @@ document.addEventListener('DOMContentLoaded', () => {
   } else {
     document.addEventListener('DOMContentLoaded', bootMiniCal);
   }
+})();
+</script>
+<script>
+(function(){
+  function syncHeaderOffset(){
+    const header = document.querySelector('.app-header');
+    if(!header) return;
+    const height = header.offsetHeight;
+    document.documentElement.style.setProperty('--app-header-offset', height + 'px');
+  }
+
+  if(document.readyState === 'complete' || document.readyState === 'interactive'){
+    syncHeaderOffset();
+  } else {
+    document.addEventListener('DOMContentLoaded', syncHeaderOffset, {once:true});
+  }
+  window.addEventListener('load', syncHeaderOffset, {once:true});
+  window.addEventListener('resize', syncHeaderOffset);
 })();
 </script>
 <!-- Injected: Weekly summary save + auto-close on Save -->


### PR DESCRIPTION
## Summary
- keep the floating totals toolbar pinned beneath the header by using the header height as a CSS variable
- default the offset variable and update it on load/resize so Total Bayar, search, and Ganti Mode remain fixed while scrolling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e71480b2c483339bdf8d474fd05677