### PR TITLE
Add Cloudflare Pages KV snapshot endpoints and client helpers

### DIFF
--- a/form.html
+++ b/form.html
@@ -2100,6 +2100,8 @@ document.addEventListener('DOMContentLoaded', () => {
 })();
 </script>
 
+<script type="module" src="/assets/js/config.js"></script>
+
 <script type="module">
   import { ensureApiClient, buildSnapshotKey, summarizeRows, showToast, formatError } from './assets/js/upah-core.js';
 
@@ -2515,6 +2517,32 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('change', scheduleSave);
 
   window.upahAutosave = { key: formKey, storageKey: AUTOKEY };
+</script>
+
+<script type="module">
+  import { saveSnapshot } from '/assets/js/config.js';
+
+  const form = document.querySelector('form');
+  form?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const fd = new FormData(form);
+    const data = Object.fromEntries(fd.entries());
+    data.form_id = data.form_id || 'upah-tukang-7hari';
+    data.periodeStart = data.periodeStart || '';
+    data.periodeEnd = data.periodeEnd || '';
+    data.rumah = data.rumah || '';
+
+    try {
+      const res = await saveSnapshot(data);
+      if (res?.ok) {
+        alert(`Tersimpan sebagai: ${res.key}`);
+      } else {
+        alert(`Gagal: ${res?.error || 'Tidak diketahui'}`);
+      }
+    } catch (err) {
+      alert(`Gagal: ${err?.message || err}`);
+    }
+  });
 </script>
 
 </body>

--- a/functions/api/list.js
+++ b/functions/api/list.js
@@ -1,37 +1,33 @@
-import { getKVBinding } from './_kv';
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
 
-function json(data, { status = 200, headers = {} } = {}) {
-  return new Response(JSON.stringify(data), {
-    status,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET,OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
-      ...headers
-    }
-  });
-}
-
-export async function onRequest({ request, env }) {
-  if (request.method === 'OPTIONS') {
-    return json({}, { status: 204 });
+export async function onRequestGet({ request, env }) {
+  if (request.method.toUpperCase() === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
   }
 
   if (request.method.toUpperCase() !== 'GET') {
-    return json({ ok: false, error: 'Method not allowed' }, { status: 405 });
+    return new Response(JSON.stringify({ ok: false, error: 'Method not allowed' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
   }
 
-  const { kv } = getKVBinding(env);
+  const kv = env?.UPAH_KV;
   if (!kv) {
-    return json({ ok: false, error: 'KV binding UPAH_KV not found' }, { status: 500 });
+    return new Response(JSON.stringify({ ok: false, error: 'KV binding UPAH_KV not found' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
   }
 
   const url = new URL(request.url);
   const prefix = url.searchParams.get('prefix') || 'ut:snap:';
-  const limitParam = url.searchParams.get('limit');
   const cursor = url.searchParams.get('cursor') || undefined;
-  const withValues = url.searchParams.get('values') === '1';
+  const limitParam = url.searchParams.get('limit');
 
   let limit = Number.parseInt(limitParam || '100', 10);
   if (!Number.isFinite(limit) || limit <= 0) {
@@ -40,45 +36,26 @@ export async function onRequest({ request, env }) {
   limit = Math.min(Math.max(limit, 1), 500);
 
   try {
-    const options = { prefix, limit };
-    if (cursor) {
-      options.cursor = cursor;
-    }
+    const { keys: batch = [], list_complete: complete, cursor: nextCursor = '' } = await kv.list({ prefix, cursor, limit });
+    const keys = batch.map((entry) => ({ name: entry.name }));
 
-    const iter = await kv.list(options);
-    const items = [];
-    const keys = [];
-
-    for (const entry of iter.keys || []) {
-      const baseMeta = entry.metadata || {};
-      let value;
-      let metadata = baseMeta;
-
-      if (withValues) {
-        const detail = await kv.getWithMetadata(entry.name, { type: 'json' });
-        value = detail?.value ?? null;
-        metadata = detail?.metadata ?? baseMeta ?? {};
-      }
-
-      items.push({
-        key: entry.name,
-        metadata,
-        ...(withValues ? { value } : {})
-      });
-      keys.push({ name: entry.name, metadata: metadata || {} });
-    }
-
-    return json({
+    return new Response(JSON.stringify({
       ok: true,
       prefix,
-      count: items.length,
-      cursor: iter.cursor || '',
-      list_complete: Boolean(iter.list_complete),
-      items,
+      count: keys.length,
+      cursor: nextCursor || '',
+      list_complete: Boolean(complete),
       keys
+    }), {
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
     });
   } catch (err) {
     console.error('api/list error', err);
-    return json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+    return new Response(JSON.stringify({ ok: false, error: String(err) }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders }
+    });
   }
 }
+
+export const onRequest = onRequestGet;

--- a/functions/api/state.js
+++ b/functions/api/state.js
@@ -1,79 +1,153 @@
-import { getKVBinding } from './_kv';
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
 
-function json(data, { status = 200, headers = {} } = {}) {
+function jsonResponse(data, { status = 200, headers = {} } = {}) {
   return new Response(JSON.stringify(data), {
     status,
     headers: {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type',
+      ...corsHeaders,
       ...headers
     }
   });
+}
+
+function sanitizeMetadata(input) {
+  const result = {};
+  Object.entries(input || {}).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value === 'object') {
+      try {
+        result[key] = JSON.stringify(value);
+      } catch (err) {
+        result[key] = String(value);
+      }
+      return;
+    }
+    result[key] = value;
+  });
+  return result;
+}
+
+function buildSnapshotKey(source = {}) {
+  const now = new Date();
+  const timestamp = now.toISOString().replace(/[:.]/g, '');
+  const uuid = (typeof crypto !== 'undefined' && crypto.randomUUID
+    ? crypto.randomUUID().slice(0, 8)
+    : Math.random().toString(36).slice(2, 10));
+
+  const periodeStart = source.periodeStart || source.start || '';
+  const periodeEnd = source.periodeEnd || source.end || '';
+  const rumah = source.rumah || source.rumahLabel || '';
+
+  if (periodeStart && periodeEnd && rumah) {
+    return { key: `ut:snap:${periodeStart}:${periodeEnd}:${rumah}:${timestamp}-${uuid}`, now };
+  }
+
+  return { key: `ut:snap:${timestamp}-${uuid}`, now };
 }
 
 export async function onRequest(context) {
   const { request, env } = context;
   const url = new URL(request.url);
   const method = request.method.toUpperCase();
-  const keyParam = url.searchParams.get('key');
 
   if (method === 'OPTIONS') {
-    return json({}, { status: 204 });
+    return new Response(null, { headers: corsHeaders });
   }
 
-  const { kv } = getKVBinding(env);
+  const kv = env?.UPAH_KV;
   if (!kv) {
-    return json({ ok: false, error: 'KV binding UPAH_KV not found' }, { status: 500 });
+    return jsonResponse({ ok: false, error: 'KV binding UPAH_KV not found' }, { status: 500 });
   }
+
+  const keyParam = url.searchParams.get('key');
 
   try {
-    if (method === 'GET') {
-      if (!keyParam) {
-        return json({ ok: false, error: 'key required' }, { status: 400 });
+    if (method === 'POST') {
+      let body;
+      try {
+        body = await request.json();
+      } catch (err) {
+        return jsonResponse({ ok: false, error: 'Body kosong/invalid' }, { status: 400 });
       }
-      const result = await kv.getWithMetadata(keyParam, { type: 'json' });
-      const value = result?.value ?? null;
-      const meta = result?.metadata ?? null;
-      return json({ ok: true, key: keyParam, value, meta });
+
+      if (!body || typeof body !== 'object') {
+        return jsonResponse({ ok: false, error: 'Body kosong/invalid' }, { status: 400 });
+      }
+
+      const candidateData = body.data ?? body.value ?? body;
+      const data = typeof candidateData === 'object' && candidateData !== null
+        ? candidateData
+        : body;
+
+      let key = body.key || keyParam;
+      let createdAt = new Date();
+      if (!key) {
+        const generated = buildSnapshotKey(data);
+        key = generated.key;
+        createdAt = generated.now;
+      }
+
+      const savedAt = createdAt.toISOString();
+      const metaPayload = (body.meta && typeof body.meta === 'object') ? body.meta : undefined;
+      const kvMeta = sanitizeMetadata({
+        form_id: data.form_id || body.form_id || metaPayload?.form_id || 'unknown',
+        start: metaPayload?.start ?? data.periodeStart ?? data.start ?? null,
+        end: metaPayload?.end ?? data.periodeEnd ?? data.end ?? null,
+        rumah: metaPayload?.rumah ?? data.rumah ?? data.rumahLabel ?? null,
+        saved_at: savedAt
+      });
+
+      const snapshot = {
+        snapshot_id: key,
+        saved_at: savedAt,
+        schema_version: '1.0.0',
+        data
+      };
+
+      if (metaPayload) {
+        snapshot.meta = metaPayload;
+      }
+
+      await kv.put(key, JSON.stringify(snapshot), { metadata: kvMeta });
+
+      return jsonResponse({ ok: true, key, saved_at: savedAt });
     }
 
-    if (method === 'POST') {
-      let payload;
-      try {
-        payload = await request.json();
-      } catch (err) {
-        payload = {};
+    if (method === 'GET') {
+      if (!keyParam) {
+        return jsonResponse({ ok: false, error: 'key wajib' }, { status: 400 });
       }
-
-      const key = payload?.key || keyParam;
-      if (!key) {
-        return json({ ok: false, error: 'key required' }, { status: 400 });
+      const raw = await kv.get(keyParam);
+      if (!raw) {
+        return jsonResponse({ ok: false, error: 'not found' }, { status: 404 });
       }
-
-      const value = payload?.value ?? null;
-      const meta = payload && typeof payload.meta === 'object' && payload.meta !== null
-        ? payload.meta
-        : null;
-
-      const options = meta ? { metadata: meta } : undefined;
-      await kv.put(key, JSON.stringify(value), options);
-
-      return json({ ok: true, key, meta });
+      return new Response(raw, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders
+        }
+      });
     }
 
     if (method === 'DELETE') {
       if (!keyParam) {
-        return json({ ok: false, error: 'key required' }, { status: 400 });
+        return jsonResponse({ ok: false, error: 'key wajib' }, { status: 400 });
       }
       await kv.delete(keyParam);
-      return json({ ok: true, key: keyParam });
+      return jsonResponse({ ok: true, deleted: keyParam });
     }
 
-    return json({ ok: false, error: 'Method not allowed' }, { status: 405 });
+    return jsonResponse({ ok: false, error: 'Method not allowed' }, { status: 405 });
   } catch (err) {
     console.error('api/state error', err);
-    return json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+    return jsonResponse({ ok: false, error: String(err) }, { status: 500 });
   }
 }

--- a/rekap.html
+++ b/rekap.html
@@ -118,6 +118,7 @@
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" integrity="sha384-QfX1QE4G6dxj7hjz9YZhhGZgxUwZjAyNWBo2fZK8Fn0vIUtS7gPAOfpRJ4VCJ06Y" crossorigin="anonymous"></script>
+  <script type="module" src="/assets/js/config.js"></script>
   <script type="module">
     import { utils, showToast, formatError, ensureApiClient } from './assets/js/upah-core.js';
 


### PR DESCRIPTION
## Summary
- implement the /api/state function to persist, fetch, and delete snapshots in the UPAH_KV binding with automatic key generation and metadata handling
- update the /api/list function to enumerate snapshot keys for Cloudflare Pages deployments
- refresh the shared client helpers and page scripts to use the new snapshot API helpers on form and rekap views

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68e71d1889a4833392d1746f123c5d82