### PR TITLE
Ensure Pages functions use UPAH_KV binding

### DIFF
--- a/functions/api/list.js
+++ b/functions/api/list.js
@@ -4,24 +4,21 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type'
 };
 
+function kvMissingResponse() {
+  return new Response(JSON.stringify({ ok: false, error: 'KV binding UPAH_KV not found' }), {
+    status: 500,
+    headers: { 'Content-Type': 'application/json', ...corsHeaders }
+  });
+}
+
+export function onRequestOptions() {
+  return new Response(null, { headers: corsHeaders });
+}
+
 export async function onRequestGet({ request, env }) {
-  if (request.method.toUpperCase() === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
-
-  if (request.method.toUpperCase() !== 'GET') {
-    return new Response(JSON.stringify({ ok: false, error: 'Method not allowed' }), {
-      status: 405,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders }
-    });
-  }
-
   const kv = env?.UPAH_KV;
   if (!kv) {
-    return new Response(JSON.stringify({ ok: false, error: 'KV binding UPAH_KV not found' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders }
-    });
+    return kvMissingResponse();
   }
 
   const url = new URL(request.url);
@@ -57,5 +54,3 @@ export async function onRequestGet({ request, env }) {
     });
   }
 }
-
-export const onRequest = onRequestGet;

--- a/functions/api/state.js
+++ b/functions/api/state.js
@@ -52,102 +52,141 @@ function buildSnapshotKey(source = {}) {
   return { key: `ut:snap:${timestamp}-${uuid}`, now };
 }
 
-export async function onRequest(context) {
-  const { request, env } = context;
-  const url = new URL(request.url);
-  const method = request.method.toUpperCase();
-
-  if (method === 'OPTIONS') {
-    return new Response(null, { headers: corsHeaders });
-  }
-
+function getKVBinding(env) {
   const kv = env?.UPAH_KV;
   if (!kv) {
-    return jsonResponse({ ok: false, error: 'KV binding UPAH_KV not found' }, { status: 500 });
+    return {
+      kv: null,
+      errorResponse: jsonResponse(
+        { ok: false, error: 'KV binding UPAH_KV not found' },
+        { status: 500 }
+      )
+    };
   }
 
-  const keyParam = url.searchParams.get('key');
+  return { kv };
+}
+
+export function onRequestOptions() {
+  return new Response(null, { headers: corsHeaders });
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  const { kv, errorResponse } = getKVBinding(env);
+  if (!kv) {
+    return errorResponse;
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch (err) {
+    return jsonResponse({ ok: false, error: 'Body kosong/invalid' }, { status: 400 });
+  }
+
+  if (!body || typeof body !== 'object') {
+    return jsonResponse({ ok: false, error: 'Body kosong/invalid' }, { status: 400 });
+  }
 
   try {
-    if (method === 'POST') {
-      let body;
-      try {
-        body = await request.json();
-      } catch (err) {
-        return jsonResponse({ ok: false, error: 'Body kosong/invalid' }, { status: 400 });
-      }
+    const url = new URL(request.url);
+    const keyParam = url.searchParams.get('key');
+    const candidateData = body.data ?? body.value ?? body;
+    const data = typeof candidateData === 'object' && candidateData !== null
+      ? candidateData
+      : body;
 
-      if (!body || typeof body !== 'object') {
-        return jsonResponse({ ok: false, error: 'Body kosong/invalid' }, { status: 400 });
-      }
-
-      const candidateData = body.data ?? body.value ?? body;
-      const data = typeof candidateData === 'object' && candidateData !== null
-        ? candidateData
-        : body;
-
-      let key = body.key || keyParam;
-      let createdAt = new Date();
-      if (!key) {
-        const generated = buildSnapshotKey(data);
-        key = generated.key;
-        createdAt = generated.now;
-      }
-
-      const savedAt = createdAt.toISOString();
-      const metaPayload = (body.meta && typeof body.meta === 'object') ? body.meta : undefined;
-      const kvMeta = sanitizeMetadata({
-        form_id: data.form_id || body.form_id || metaPayload?.form_id || 'unknown',
-        start: metaPayload?.start ?? data.periodeStart ?? data.start ?? null,
-        end: metaPayload?.end ?? data.periodeEnd ?? data.end ?? null,
-        rumah: metaPayload?.rumah ?? data.rumah ?? data.rumahLabel ?? null,
-        saved_at: savedAt
-      });
-
-      const snapshot = {
-        snapshot_id: key,
-        saved_at: savedAt,
-        schema_version: '1.0.0',
-        data
-      };
-
-      if (metaPayload) {
-        snapshot.meta = metaPayload;
-      }
-
-      await kv.put(key, JSON.stringify(snapshot), { metadata: kvMeta });
-
-      return jsonResponse({ ok: true, key, saved_at: savedAt });
+    let key = body.key || keyParam;
+    let createdAt = new Date();
+    if (!key) {
+      const generated = buildSnapshotKey(data);
+      key = generated.key;
+      createdAt = generated.now;
     }
 
-    if (method === 'GET') {
-      if (!keyParam) {
-        return jsonResponse({ ok: false, error: 'key wajib' }, { status: 400 });
-      }
-      const raw = await kv.get(keyParam);
-      if (!raw) {
-        return jsonResponse({ ok: false, error: 'not found' }, { status: 404 });
-      }
-      return new Response(raw, {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        }
-      });
+    const savedAt = createdAt.toISOString();
+    const metaPayload = (body.meta && typeof body.meta === 'object') ? body.meta : undefined;
+    const kvMeta = sanitizeMetadata({
+      form_id: data.form_id || body.form_id || metaPayload?.form_id || 'unknown',
+      start: metaPayload?.start ?? data.periodeStart ?? data.start ?? null,
+      end: metaPayload?.end ?? data.periodeEnd ?? data.end ?? null,
+      rumah: metaPayload?.rumah ?? data.rumah ?? data.rumahLabel ?? null,
+      saved_at: savedAt
+    });
+
+    const snapshot = {
+      snapshot_id: key,
+      saved_at: savedAt,
+      schema_version: '1.0.0',
+      data
+    };
+
+    if (metaPayload) {
+      snapshot.meta = metaPayload;
     }
 
-    if (method === 'DELETE') {
-      if (!keyParam) {
-        return jsonResponse({ ok: false, error: 'key wajib' }, { status: 400 });
-      }
-      await kv.delete(keyParam);
-      return jsonResponse({ ok: true, deleted: keyParam });
-    }
+    await kv.put(key, JSON.stringify(snapshot), { metadata: kvMeta });
 
-    return jsonResponse({ ok: false, error: 'Method not allowed' }, { status: 405 });
+    return jsonResponse({ ok: true, key, saved_at: savedAt });
   } catch (err) {
-    console.error('api/state error', err);
+    console.error('api/state POST error', err);
+    return jsonResponse({ ok: false, error: String(err) }, { status: 500 });
+  }
+}
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const { kv, errorResponse } = getKVBinding(env);
+  if (!kv) {
+    return errorResponse;
+  }
+
+  try {
+    const url = new URL(request.url);
+    const keyParam = url.searchParams.get('key');
+
+    if (!keyParam) {
+      return jsonResponse({ ok: false, error: 'key wajib' }, { status: 400 });
+    }
+
+    const raw = await kv.get(keyParam);
+    if (!raw) {
+      return jsonResponse({ ok: false, error: 'not found' }, { status: 404 });
+    }
+
+    return new Response(raw, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        ...corsHeaders
+      }
+    });
+  } catch (err) {
+    console.error('api/state GET error', err);
+    return jsonResponse({ ok: false, error: String(err) }, { status: 500 });
+  }
+}
+
+export async function onRequestDelete(context) {
+  const { request, env } = context;
+  const { kv, errorResponse } = getKVBinding(env);
+  if (!kv) {
+    return errorResponse;
+  }
+
+  try {
+    const url = new URL(request.url);
+    const keyParam = url.searchParams.get('key');
+
+    if (!keyParam) {
+      return jsonResponse({ ok: false, error: 'key wajib' }, { status: 400 });
+    }
+
+    await kv.delete(keyParam);
+    return jsonResponse({ ok: true, deleted: keyParam });
+  } catch (err) {
+    console.error('api/state DELETE error', err);
     return jsonResponse({ ok: false, error: String(err) }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- refactor the state function into method-specific handlers that consistently use the env.UPAH_KV binding
- add an OPTIONS handler and shared binding guard to the list function to align with the UPAH_KV name

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e725d05fb8833393759317a9f3e1fd