### PR TITLE
Normalize period metadata to yyyy-mm-dd

### DIFF
--- a/form.html
+++ b/form.html
@@ -669,6 +669,8 @@
           <button class="btn" data-testid="form-save" onclick="handleSaveAndRedirect(event)">Simpan</button>
           <button class="btn" onclick="window.print()">Cetak</button>
           <button class="btn" onclick="try{downloadCSV&&downloadCSV()}catch(_){alert('downloadCSV tidak ditemukan')}">Unduh CSV</button>
+          <button class="btn" onclick="try{uploadCsvFromFile&&uploadCsvFromFile()}catch(_){alert('uploadCsvFromFile tidak ditemukan')}">Upload CSV</button>
+          <button class="btn" onclick="try{uploadFromClipboard&&uploadFromClipboard()}catch(_){alert('uploadFromClipboard tidak ditemukan')}">Upload Clipboard</button>
           <button class="btn" onclick="try{downloadJSON&&downloadJSON()}catch(_){alert('downloadJSON tidak ditemukan')}">Unduh JSON</button>
           <button class="btn small" onclick="restoreDefaultRows()">Kosongkan</button>
           <button class="btn primary" onclick="addWorker()">+ Pekerja</button>
@@ -1576,6 +1578,259 @@ const upahPokok = hari * rate;
       alert('Gagal mengekspor CSV: ' + err.message);
     }
   }
+
+  function _decodeCsvPayload(raw){
+    const text = (raw == null ? '' : String(raw)).trim();
+    if (!text) return '';
+    if (/^data:text\/csv;base64,/i.test(text)){
+      try{
+        return atob(text.split(',')[1] || '');
+      }catch(err){
+        throw new Error('Gagal membaca data base64 dari CSV');
+      }
+    }
+    return text;
+  }
+
+  function _parseCsvRows(content){
+    const rows = [];
+    let current = [];
+    let value = '';
+    let inQuotes = false;
+    const text = content.replace(/^\uFEFF/, '');
+    for(let i=0; i<text.length; i++){
+      const ch = text[i];
+      if(inQuotes){
+        if(ch === '"'){
+          if(text[i+1] === '"'){
+            value += '"';
+            i++;
+          } else {
+            inQuotes = false;
+          }
+        } else {
+          value += ch;
+        }
+        continue;
+      }
+      if(ch === '"'){
+        inQuotes = true;
+        continue;
+      }
+      if(ch === ','){
+        current.push(value);
+        value = '';
+        continue;
+      }
+      if(ch === '\r'){
+        if(text[i+1] === '\n') i++;
+        current.push(value);
+        rows.push(current);
+        current = [];
+        value = '';
+        continue;
+      }
+      if(ch === '\n'){
+        current.push(value);
+        rows.push(current);
+        current = [];
+        value = '';
+        continue;
+      }
+      value += ch;
+    }
+    if(inQuotes){
+      throw new Error('Format CSV tidak valid (kutip tidak ditutup)');
+    }
+    if(value.length || current.length){
+      current.push(value);
+      rows.push(current);
+    }
+    return rows;
+  }
+
+  function _extractCsvData(raw){
+    const decoded = _decodeCsvPayload(raw);
+    if(!decoded){
+      throw new Error('Data CSV kosong');
+    }
+    const parsed = _parseCsvRows(decoded);
+    if(!parsed.length){
+      throw new Error('Baris CSV tidak ditemukan');
+    }
+
+    let header = null;
+    const dataRows = [];
+    let periodStart = '';
+    let periodEnd = '';
+
+    const clean = (val) => {
+      const str = val == null ? '' : String(val);
+      return str.replace(/^\uFEFF/, '');
+    };
+
+    parsed.forEach((rowRaw) => {
+      const row = rowRaw.map(clean);
+      const trimmed = row.map(v => v.trim());
+      if(!header){
+        if(trimmed.every(v => !v)) return;
+        const first = (trimmed[0] || '').toLowerCase();
+        if(first === 'periode mulai'){
+          if(trimmed[1]) periodStart = trimmed[1];
+          return;
+        }
+        if(first === 'periode selesai'){
+          if(trimmed[1]) periodEnd = trimmed[1];
+          return;
+        }
+        if(first === 'no' && trimmed.some(v => v.toLowerCase() === 'nama')){
+          header = row;
+        }
+        return;
+      }
+      if(trimmed.every(v => !v)) return;
+      dataRows.push(row);
+    });
+
+    if(!header){
+      throw new Error('Header data CSV tidak ditemukan');
+    }
+    if(!dataRows.length){
+      throw new Error('Tidak ada baris pekerja pada CSV');
+    }
+
+    const headerTrimmed = header.map(v => v.trim());
+    const headerLower = headerTrimmed.map(v => v.toLowerCase());
+    const idxNama = headerLower.indexOf('nama');
+    const idxKelas = headerLower.indexOf('kelas');
+    const idxGroup = headerLower.indexOf('group');
+    const idxKet = headerLower.indexOf('keterangan');
+    const idxBonus = headerLower.indexOf('bonus');
+    const dayIdxMap = displayDayKeys.map(day => headerLower.indexOf(day.toLowerCase()));
+
+    const importedRows = dataRows.map((row) => {
+      const cells = row.map(v => v.trim());
+      const next = { nama:'', kelas:'Tukang', group:'', rumah:['','','','','','',''], ket:'', bonus:'' };
+      if(idxNama >= 0) next.nama = cells[idxNama] || '';
+      if(idxKelas >= 0 && cells[idxKelas]) next.kelas = cells[idxKelas];
+      if(idxGroup >= 0) next.group = cells[idxGroup] || '';
+      if(idxKet >= 0) next.ket = cells[idxKet] || '';
+      if(idxBonus >= 0) next.bonus = (cells[idxBonus] || '').replace(/[^0-9]/g,'');
+      dayIdxMap.forEach((colIdx, orderIdx) => {
+        if(colIdx < 0) return;
+        const val = cells[colIdx] || '';
+        next.rumah[displayDayOrder[orderIdx]] = val;
+      });
+      return next;
+    });
+
+    return {
+      rows: importedRows,
+      period: {
+        start: periodStart.trim(),
+        end: periodEnd.trim()
+      }
+    };
+  }
+
+  function _applyImportedPeriod(period){
+    if(!period || typeof period !== 'object') return;
+    const hasStart = Object.prototype.hasOwnProperty.call(period, 'start');
+    const hasEnd = Object.prototype.hasOwnProperty.call(period, 'end');
+    if(!hasStart && !hasEnd) return;
+    const payload = {};
+    if(hasStart) payload.start = period.start || '';
+    if(hasEnd) payload.end = period.end || '';
+    if(window.upahFormBridge && typeof window.upahFormBridge.setPeriod === 'function'){
+      window.upahFormBridge.setPeriod(payload);
+      return;
+    }
+    try{
+      const startEl = document.getElementById('periodStart');
+      const endEl = document.getElementById('periodEnd');
+      if(hasStart && startEl){
+        startEl.value = payload.start;
+        localStorage.setItem('upah20_periodStart', payload.start);
+      }
+      if(hasEnd && endEl){
+        endEl.value = payload.end;
+        localStorage.setItem('upah20_periodEnd', payload.end);
+      }
+    }catch(err){
+      console.warn('Gagal menerapkan periode dari CSV', err);
+    }
+  }
+
+  function _applyImportedRows(importedRows){
+    if(window.upahFormBridge && typeof window.upahFormBridge.setRows === 'function'){
+      window.upahFormBridge.setRows(importedRows);
+      return;
+    }
+    rows = normaliseRows(importedRows);
+    save('rows', rows);
+    rerender();
+  }
+
+  async function _importCsv(raw, label){
+    const sourceLabel = label || 'CSV';
+    const { rows: importedRows, period } = _extractCsvData(raw);
+    if(!importedRows.length){
+      throw new Error('Tidak ada data pekerja yang dapat dimuat');
+    }
+    const proceed = window.confirm(`Timpa data saat ini dengan ${importedRows.length} baris dari ${sourceLabel}?`);
+    if(!proceed) return;
+    _applyImportedRows(importedRows);
+    _applyImportedPeriod(period);
+    alert(`Data dari ${sourceLabel} berhasil dimuat.`);
+  }
+
+  async function uploadCsvFromFile(){
+    try{
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = '.csv,text/csv';
+      input.style.display = 'none';
+      document.body.appendChild(input);
+      input.addEventListener('change', async () => {
+        const file = input.files && input.files[0];
+        input.remove();
+        if(!file) return;
+        try{
+          const text = await file.text();
+          await _importCsv(text, file.name || 'berkas CSV');
+        }catch(err){
+          console.error(err);
+          alert('Gagal memuat CSV: ' + err.message);
+        }
+      }, { once: true });
+      input.click();
+      setTimeout(() => { if(document.body.contains(input)) input.remove(); }, 2000);
+    }catch(err){
+      console.error(err);
+      alert('Tidak dapat membuka dialog unggah CSV: ' + err.message);
+    }
+  }
+
+  async function uploadFromClipboard(){
+    try{
+      if(!navigator.clipboard || typeof navigator.clipboard.readText !== 'function'){
+        alert('Clipboard API tidak tersedia di browser ini.');
+        return;
+      }
+      const text = await navigator.clipboard.readText();
+      if(!text || !text.trim()){
+        alert('Clipboard tidak berisi data.');
+        return;
+      }
+      await _importCsv(text, 'Clipboard');
+    }catch(err){
+      console.error(err);
+      alert('Gagal membaca data dari clipboard: ' + err.message);
+    }
+  }
+
+  window.uploadCsvFromFile = uploadCsvFromFile;
+  window.uploadFromClipboard = uploadFromClipboard;
 
 
 

--- a/form.html
+++ b/form.html
@@ -666,7 +666,7 @@
           </div>
         </div>
         <div class="row">
-          <button class="btn" data-testid="form-save" onclick="try{saveAll&&saveAll()}catch(_){ if (typeof save==='function') save('rows', window.rows); else alert('Fungsi simpan tidak tersedia'); }">Simpan</button>
+          <button class="btn" data-testid="form-save" onclick="handleSaveAndRedirect(event)">Simpan</button>
           <button class="btn" onclick="window.print()">Cetak</button>
           <button class="btn" onclick="try{downloadCSV&&downloadCSV()}catch(_){alert('downloadCSV tidak ditemukan')}">Unduh CSV</button>
           <button class="btn" onclick="try{downloadJSON&&downloadJSON()}catch(_){alert('downloadJSON tidak ditemukan')}">Unduh JSON</button>
@@ -1462,36 +1462,115 @@ const upahPokok = hari * rate;
     }
   }
 
+  function resolvePeriodMetadata(){
+    let start = '';
+    let end = '';
+
+    try{
+      if(typeof readPeriod === 'function'){
+        const direct = readPeriod();
+        if(direct && typeof direct === 'object'){
+          if(!start && direct.start) start = String(direct.start).trim();
+          if(!end && direct.end) end = String(direct.end).trim();
+        }
+      }
+    }catch(err){
+      console.warn('resolvePeriodMetadata via readPeriod gagal', err);
+    }
+
+    try{
+      if(!start){
+        const startEl = document.getElementById('periodStart');
+        if(startEl && startEl.value) start = String(startEl.value).trim();
+      }
+      if(!end){
+        const endEl = document.getElementById('periodEnd');
+        if(endEl && endEl.value) end = String(endEl.value).trim();
+      }
+    }catch(err){
+      console.warn('resolvePeriodMetadata via DOM gagal', err);
+    }
+
+    try{
+      if(!start){
+        const storedStart = window.localStorage.getItem('upah20_periodStart');
+        if(storedStart) start = String(storedStart).trim();
+      }
+      if(!end){
+        const storedEnd = window.localStorage.getItem('upah20_periodEnd');
+        if(storedEnd) end = String(storedEnd).trim();
+      }
+    }catch(err){
+      console.warn('resolvePeriodMetadata via localStorage gagal', err);
+    }
+
+    if(!start || !end){
+      try{
+        const historyRaw = window.localStorage.getItem('upah20_period_history_v2');
+        if(historyRaw){
+          const history = JSON.parse(historyRaw);
+          if(Array.isArray(history) && history.length){
+            const latest = history[history.length-1] || {};
+            if(!start && latest.periodeMulai) start = String(latest.periodeMulai).trim();
+            if(!end && latest.periodeSelesai) end = String(latest.periodeSelesai).trim();
+          }
+        }
+      }catch(err){
+        console.warn('resolvePeriodMetadata via history gagal', err);
+      }
+    }
+
+    const normalizedStart = normalizePeriodDate(start);
+    let normalizedEnd = normalizePeriodDate(end);
+    if(!normalizedEnd && normalizedStart){
+      normalizedEnd = normalizePeriodDate(addDays(normalizedStart, 6));
+    }
+
+    return { start: normalizedStart || '', end: normalizedEnd || '' };
+  }
+
+  function buildCsvSnapshot(){
+    const period = resolvePeriodMetadata();
+    const headers = [
+      'No','Nama','Kelas','Group','Rate',
+      ...displayDayKeys, 'Hari','Upah Pokok','Uang Beras','Total','Keterangan'
+    ];
+    const lines = [
+      ['Periode Mulai', period.start || ''].map(_csvEscape).join(','),
+      ['Periode Selesai', period.end || ''].map(_csvEscape).join(','),
+      '',
+      headers.map(_csvEscape).join(',')
+    ];
+
+    rows.forEach((r, idx)=>{
+      const calc = rowCalc(r);
+      const rowVals = [
+        idx+1,
+        r.nama||'',
+        r.kelas||'',
+        r.group||'',
+        calc.rate||0,
+        ...displayDayOrder.map(di=> (r.rumah||[])[di]||''),
+        calc.hari||0,
+        calc.upahPokok||0,
+        calc.uangBeras||0,
+        calc.totalBayar||0,
+        r.ket||''
+      ];
+
+      lines.push(rowVals.map(_csvEscape).join(','));
+    });
+
+    const csv = lines.join('\r\n');
+    return { csv, filename: _timestampName('upah7hari', 'csv') };
+  }
+  window.buildCsvSnapshot = buildCsvSnapshot;
+
   // Export CSV (tampilan tabel pekerja)
   function downloadCSV(){
     try{
-      const headers = [
-        'No','Nama','Kelas','Group','Rate',
-        ...displayDayKeys, 'Hari','Upah Pokok','Uang Beras','Total','Keterangan'
-      ];
-      const lines = [ headers.map(_csvEscape).join(',') ];
-
-      rows.forEach((r, idx)=>{
-        const calc = rowCalc(r);
-        const rowVals = [
-          idx+1,
-          r.nama||'',
-          r.kelas||'',
-          r.group||'',
-          calc.rate||0,
-          ...displayDayOrder.map(di=> (r.rumah||[])[di]||''),
-          calc.hari||0,
-          calc.upahPokok||0,
-          calc.uangBeras||0,
-          calc.totalBayar||0,
-          r.ket||''
-        ];
-        
-        lines.push(rowVals.map(_csvEscape).join(','));
-      });
-
-      const csv = lines.join('\r\n');
-      _downloadBlob(csv, 'text/csv;charset=utf-8', _timestampName('upah7hari', 'csv'));
+      const { csv, filename } = buildCsvSnapshot();
+      _downloadBlob(csv, 'text/csv;charset=utf-8', filename);
     }catch(err){
       console.error(err);
       alert('Gagal mengekspor CSV: ' + err.message);
@@ -1929,7 +2008,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 })();
 </script>
-<!-- Injected: Weekly summary save + auto-close on Save -->
+<!-- Injected: Weekly summary save + redirect to index & WhatsApp on Save -->
 <script>
 (function(){
   const KEY_ROWS='upah20_rows', KEY_RATES='upah20_classRates', KEY_THRESH='upah20_beras_threshold', KEY_AMT='upah20_beras_amount', KEY_HISTORY='upah20_period_history_v2';
@@ -1948,29 +2027,179 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   function toISO(d){const x=new Date(d); return isNaN(x)?'':x.toISOString().slice(0,10);}
   function addDays(s,n){const d=new Date(s); d.setDate(d.getDate()+n); return toISO(d);}
+  function normalizePeriodDate(value){
+    const raw = (value??'').toString().trim();
+    if(!raw) return '';
+    const isoMatch = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if(isoMatch) return `${isoMatch[1]}-${isoMatch[2]}-${isoMatch[3]}`;
+    const ymdMatch = raw.match(/^(\d{4})[^\d](\d{1,2})[^\d](\d{1,2})$/);
+    if(ymdMatch){
+      const y = Number(ymdMatch[1]);
+      const m = Number(ymdMatch[2]);
+      const d = Number(ymdMatch[3]);
+      if(y && m>=1 && m<=12 && d>=1 && d<=31){
+        const dt = new Date(Date.UTC(y, m-1, d));
+        if(dt.getUTCFullYear()===y && dt.getUTCMonth()===m-1 && dt.getUTCDate()===d){
+          return `${y}-${String(m).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        }
+      }
+    }
+    const dmyMatch = raw.match(/^(\d{1,2})[^\d](\d{1,2})[^\d](\d{4})$/);
+    if(dmyMatch){
+      const d = Number(dmyMatch[1]);
+      const m = Number(dmyMatch[2]);
+      const y = Number(dmyMatch[3]);
+      if(y && m>=1 && m<=12 && d>=1 && d<=31){
+        const dt = new Date(Date.UTC(y, m-1, d));
+        if(dt.getUTCFullYear()===y && dt.getUTCMonth()===m-1 && dt.getUTCDate()===d){
+          return `${y}-${String(m).padStart(2,'0')}-${String(d).padStart(2,'0')}`;
+        }
+      }
+    }
+    const parsed = new Date(raw);
+    if(!Number.isNaN(parsed.getTime())){
+      const y = parsed.getFullYear();
+      const m = String(parsed.getMonth()+1).padStart(2,'0');
+      const d = String(parsed.getDate()).padStart(2,'0');
+      return `${y}-${m}-${d}`;
+    }
+    return '';
+  }
   function saveWeeklyToHistory(){
     const ps=document.getElementById('periodStart'), pe=document.getElementById('periodEnd');
-    const start=ps&&ps.value?ps.value:'', end=pe&&pe.value?pe.value:(start?addDays(start,6):'');
+    const rawStart=ps&&ps.value?ps.value:'';
+    const rawEnd=pe&&pe.value?pe.value:'';
+    const start=normalizePeriodDate(rawStart);
+    let end=normalizePeriodDate(rawEnd);
+    if(!end && start){
+      end = normalizePeriodDate(addDays(start,6));
+    }
     if(!start) return;
     const t=computeTotals();
     const rec={periodeMulai:start,periodeSelesai:end,pekerja:t.pekerja,sumHari:Math.round(t.sumHari*10)/10,sumPokok:t.sumPokok,sumBeras:t.sumBeras,sumBonus:t.sumBonus,sumTotal:t.sumTotal,ts:Date.now()};
     const arr=loadJSON(KEY_HISTORY,[]); const idx=arr.findIndex(x=>x.periodeMulai===rec.periodeMulai); if(idx>=0)arr[idx]=rec; else arr.push(rec);
     localStorage.setItem(KEY_HISTORY, JSON.stringify(arr));
   }
-  // Patch saveAll if exists
+  // Patch saveAll if exists so histori mingguan tetap tersimpan
   const _orig=window.saveAll;
   window.saveAll=function(){
-    try{ if(typeof _orig==='function') _orig(); }catch(e){}
-    try{ saveWeeklyToHistory(); }catch(e){}
-    setTimeout(function(){ try{window.close();}catch(_){}
-      setTimeout(function(){ try{window.location.replace('about:blank');}catch(_){} },200);
-    },150);
+    let result;
+    try{
+      if(typeof _orig==='function') result=_orig();
+    }catch(e){
+      console.warn('saveAll original error', e);
+    }
+    try{ saveWeeklyToHistory(); }catch(e){ console.warn('saveWeeklyToHistory error', e); }
+    return result;
   };
-  // Robust hook for any "Simpan" button
-  window.addEventListener('DOMContentLoaded', function(){
-    const btns=Array.from(document.querySelectorAll('button,[role="button"]')).filter(b=>/simpan/i.test(b.textContent||''));
-    btns.forEach(b=>b.addEventListener('click', ()=>{ setTimeout(saveWeeklyToHistory,100); setTimeout(()=>{try{window.close();}catch(_){}} ,250); }, {capture:true}));
-  });
+
+  const INDEX_URL=new URL('./index.html', window.location.href).href;
+  const WHATSAPP_BASE='https://web.whatsapp.com/send';
+  const WHATSAPP_PHONE='6281210400168';
+
+  function buildWhatsappCsvText(){
+    try{
+      const builder = typeof window.buildCsvSnapshot==='function' ? window.buildCsvSnapshot : (typeof buildCsvSnapshot==='function' ? buildCsvSnapshot : null);
+      if(builder){
+        const snapshot = builder();
+        const csv = snapshot && snapshot.csv;
+        if(csv){
+          const normalized = String(csv);
+          // Pastikan format baris mengikuti file CSV yang diunduh (CRLF)
+          return /\r\n/.test(normalized) ? normalized : normalized.replace(/\n/g, '\r\n');
+        }
+      }
+    }catch(err){
+      console.warn('buildWhatsappCsvText failed', err);
+    }
+    return '';
+  }
+
+  function buildWhatsappUrl(){
+    try{
+      const waUrl = new URL(WHATSAPP_BASE);
+      waUrl.searchParams.set('phone', WHATSAPP_PHONE);
+      const message = buildWhatsappCsvText();
+      if(message){
+        waUrl.searchParams.set('text', message);
+      }
+      return waUrl.toString();
+    }catch(err){
+      console.warn('Gagal menyusun URL WhatsApp', err);
+      try{
+        const fallback = new URL(WHATSAPP_BASE);
+        fallback.searchParams.set('phone', WHATSAPP_PHONE);
+        return fallback.toString();
+      }catch(fallbackErr){
+        console.warn('Fallback URL WhatsApp gagal', fallbackErr);
+      }
+    }
+    return WHATSAPP_BASE;
+  }
+
+  function openWhatsappWithText(){
+    const target = buildWhatsappUrl();
+    let opened = false;
+    try{
+      const newWindow = window.open(target, '_blank', 'noopener');
+      if(newWindow){
+        newWindow.opener = null;
+        opened = true;
+      }
+    }catch(err){
+      console.warn('Gagal membuka tab WhatsApp baru', err);
+    }
+    if(!opened){
+      try{
+        window.open(target, '_self');
+      }catch(openErr){
+        console.warn('Gagal menggunakan fallback WhatsApp', openErr);
+      }
+    }
+  }
+
+  async function goToIndexAndWhatsapp(){
+    try{
+      openWhatsappWithText();
+    }catch(err){
+      console.warn('openWhatsappWithText error', err);
+    }
+    try{
+      window.location.href = INDEX_URL;
+    }catch(err){
+      try{ window.location.assign(INDEX_URL); }
+      catch(assignErr){ console.warn('Gagal menuju index.html', assignErr); }
+    }
+  }
+
+  window.handleSaveAndRedirect=function(event){
+    if(event && typeof event.preventDefault==='function') event.preventDefault();
+    const finalize = ()=> goToIndexAndWhatsapp();
+    const handleFailure = (err)=>{
+      console.error('Simpan gagal', err);
+      alert('Fungsi simpan tidak tersedia');
+    };
+
+    try{
+      if(typeof window.saveAll==='function'){
+        const result=window.saveAll();
+        if(result && typeof result.then==='function'){
+          result.then(()=>finalize()).catch(err=>{ console.warn('saveAll promise rejected', err); return finalize(); });
+        } else {
+          finalize();
+        }
+        return;
+      }
+      if(typeof window.save==='function'){
+        window.save('rows', window.rows);
+        finalize();
+        return;
+      }
+      handleFailure(new Error('saveAll tidak tersedia'));
+    }catch(err){
+      handleFailure(err);
+    }
+  };
   // Auto "Kosongkan" when ?new=N
   (function(){
     const p=new URLSearchParams(location.search); const hasNew=p.has('new')||(location.hash||'').toLowerCase().includes('new');
@@ -2022,7 +2251,12 @@ document.addEventListener('DOMContentLoaded', () => {
   (function extendSave(){
     const _origSaveAll = window.saveAll;
     window.saveAll = function(){
-      try { if (typeof _origSaveAll === 'function') _origSaveAll(); } catch(e){}
+      let result;
+      try {
+        if (typeof _origSaveAll === 'function') {
+          result = _origSaveAll();
+        }
+      } catch(e){ console.warn('extendSave original saveAll error', e); }
       try {
         const ps=document.getElementById('periodStart'), pe=document.getElementById('periodEnd');
         const start=ps&&ps.value?ps.value:''; if(!start) return;
@@ -2043,6 +2277,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const idx = hist.findIndex(x => x.periodeMulai === start);
         if (idx >= 0) { hist[idx].hasSnap = true; saveJSON(KEY_HISTORY, hist); }
       } catch(e){ console.warn('Snapshot save failed', e); }
+      return result;
     };
   })();
 
@@ -2189,7 +2424,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setSaving(true);
     try {
       const { rows, classRates, rumah, allowance } = readWorkingState();
-      const period = readPeriod();
+      const period = resolvePeriodMetadata();
       const rumahLabel = deriveRumahLabel(rumah, rows);
       const allowanceThreshold = Number(allowance?.threshold ?? window.localStorage.getItem(STORAGE_KEYS.allowanceThreshold) ?? 0) || 0;
       const allowanceAmount = Number(allowance?.amount ?? window.localStorage.getItem(STORAGE_KEYS.allowanceAmount) ?? 0) || 0;

--- a/rekap.html
+++ b/rekap.html
@@ -33,7 +33,7 @@
 
   <main class="mx-auto max-w-6xl space-y-8 px-4 py-6">
     <section class="rounded-2xl bg-white p-6 shadow-sm">
-      <div class="grid gap-4 lg:grid-cols-4">
+      <div class="grid gap-4 lg:grid-cols-3">
         <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
           Periode Mulai
           <input id="filterStart" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
@@ -41,10 +41,6 @@
         <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
           Periode Selesai
           <input id="filterEnd" type="date" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
-        </label>
-        <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
-          Rumah
-          <input id="filterRumah" type="text" placeholder="BlokA" class="rounded-xl border border-slate-200 px-3 py-2 text-sm font-normal text-slate-700 focus:border-orange-400 focus:outline-none focus:ring-2 focus:ring-orange-200">
         </label>
         <label class="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wide text-slate-400">
           Pencarian Bebas
@@ -56,19 +52,6 @@
         <span class="text-slate-300">•</span>
         <button id="btnReset" class="rounded-full border border-slate-200 px-3 py-1 text-xs font-medium text-slate-600 hover:border-slate-300">Reset Filter</button>
       </div>
-    </section>
-
-    <section class="grid gap-4 md:grid-cols-2">
-      <article class="rounded-2xl bg-white p-6 shadow-sm">
-        <h2 class="text-base font-semibold text-slate-900">Total per Rumah</h2>
-        <p class="text-xs text-slate-500">Akumulasi total upah per rumah berdasarkan filter saat ini.</p>
-        <ul id="summaryRumah" class="mt-3 space-y-2 text-sm text-slate-700"></ul>
-      </article>
-      <article class="rounded-2xl bg-white p-6 shadow-sm">
-        <h2 class="text-base font-semibold text-slate-900">Total per Hari</h2>
-        <p class="text-xs text-slate-500">Akumulasi total upah berdasarkan tanggal mulai (periode).</p>
-        <ul id="summaryHari" class="mt-3 space-y-2 text-sm text-slate-700"></ul>
-      </article>
     </section>
 
     <section class="rounded-2xl bg-white p-6 shadow-sm">
@@ -90,9 +73,7 @@
           <thead class="text-left text-slate-500">
             <tr>
               <th class="py-2 pr-4 font-medium">Periode</th>
-              <th class="py-2 pr-4 font-medium">Rumah</th>
               <th class="py-2 pr-4 font-medium text-right">Total Upah</th>
-              <th class="py-2 pr-4 font-medium text-right">Total Hari</th>
               <th class="py-2 pr-4 font-medium">Terakhir Disimpan</th>
               <th class="py-2 pl-4 font-medium text-right">Aksi</th>
             </tr>
@@ -149,7 +130,6 @@
     const filterControls = {
       start: document.getElementById('filterStart'),
       end: document.getElementById('filterEnd'),
-      rumah: document.getElementById('filterRumah'),
       search: document.getElementById('filterSearch')
     };
 
@@ -266,13 +246,11 @@
     function applyFilter() {
       const startVal = filterControls.start.value;
       const endVal = filterControls.end.value;
-      const rumahVal = filterControls.rumah.value.trim().toLowerCase();
       const searchVal = filterControls.search.value.trim().toLowerCase();
 
       state.filtered = state.all.filter((item) => {
         if (startVal && (!item.start || item.start < startVal)) return false;
         if (endVal && (!item.end || item.end > endVal)) return false;
-        if (rumahVal && !String(item.rumah || '').toLowerCase().includes(rumahVal)) return false;
         if (searchVal) {
           const haystack = [item.key, item.rumah, item.start, item.end].join(' ').toLowerCase();
           if (!haystack.includes(searchVal)) return false;
@@ -298,7 +276,6 @@
         totalInfo.textContent = '0 snapshot';
         pageInfo.textContent = 'Halaman 0';
         cursorInfo.textContent = '';
-        renderSummaries([]);
         return;
       }
       tableSkeleton.classList.add('hidden');
@@ -316,9 +293,7 @@
             <div class="font-medium text-slate-800">${periode}</div>
             <div class="text-xs text-slate-400">${item.key}</div>
           </td>
-          <td class="py-3 pr-4 align-top text-slate-700">${item.rumah || '—'}</td>
           <td class="py-3 pr-4 align-top text-right font-medium text-slate-800">${utils.formatRupiah(item.total || 0)}</td>
-          <td class="py-3 pr-4 align-top text-right text-slate-600">${utils.formatNumber(item.totalDays || 0)}</td>
           <td class="py-3 pr-4 align-top text-slate-600">${updated}</td>
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
@@ -336,24 +311,6 @@
       document.getElementById('btnPrev').disabled = state.page <= 1;
       document.getElementById('btnNext').disabled = state.page >= totalPages;
       cursorInfo.textContent = `${rows.length} baris ditampilkan`;
-      renderSummaries(state.filtered);
-    }
-
-    function renderSummaries(records) {
-      const byRumah = new Map();
-      const byHari = new Map();
-      records.forEach((item) => {
-        const rumahKey = item.rumah || 'Tanpa label';
-        byRumah.set(rumahKey, (byRumah.get(rumahKey) || 0) + (item.total || 0));
-        const hariKey = item.start || 'Tanpa tanggal';
-        byHari.set(hariKey, (byHari.get(hariKey) || 0) + (item.total || 0));
-      });
-
-      const rumahList = Array.from(byRumah.entries()).sort((a, b) => b[1] - a[1]).map(([rumah, total]) => `<li class="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2"><span>${rumah}</span><span class="font-semibold">${utils.formatRupiah(total)}</span></li>`);
-      const hariList = Array.from(byHari.entries()).sort((a, b) => a[0].localeCompare(b[0])).map(([hari, total]) => `<li class="flex items-center justify-between rounded-xl border border-slate-100 px-3 py-2"><span>${hari}</span><span class="font-semibold">${utils.formatRupiah(total)}</span></li>`);
-
-      document.getElementById('summaryRumah').innerHTML = rumahList.length ? rumahList.join('') : '<li class="rounded-xl border border-dashed border-slate-200 px-3 py-2 text-xs text-slate-400">Tidak ada data</li>';
-      document.getElementById('summaryHari').innerHTML = hariList.length ? hariList.join('') : '<li class="rounded-xl border border-dashed border-slate-200 px-3 py-2 text-xs text-slate-400">Tidak ada data</li>';
     }
 
     document.getElementById('btnPrev').addEventListener('click', () => {
@@ -372,7 +329,6 @@
     document.getElementById('btnReset').addEventListener('click', () => {
       filterControls.start.value = '';
       filterControls.end.value = '';
-      filterControls.rumah.value = '';
       filterControls.search.value = '';
       applyFilter();
     });
@@ -406,33 +362,11 @@
         No: idx + 1,
         Key: item.key,
         Periode: `${item.start} s/d ${item.end}`,
-        Rumah: item.rumah,
         TotalUpah: item.total,
-        TotalHari: item.totalDays,
         UpdatedAt: item.updatedAt
       }));
-      const rumahSheet = [];
-      const rumahAcc = new Map();
-      state.filtered.forEach((item) => {
-        const key = item.rumah || 'Tanpa label';
-        rumahAcc.set(key, (rumahAcc.get(key) || 0) + (item.total || 0));
-      });
-      rumahAcc.forEach((total, rumah) => {
-        rumahSheet.push({ Rumah: rumah, TotalUpah: total });
-      });
-      const hariAcc = new Map();
-      state.filtered.forEach((item) => {
-        const key = item.start || 'Tanpa tanggal';
-        hariAcc.set(key, (hariAcc.get(key) || 0) + (item.total || 0));
-      });
-      const hariSheet = [];
-      hariAcc.forEach((total, hari) => {
-        hariSheet.push({ PeriodeMulai: hari, TotalUpah: total });
-      });
       utils.toXLSX('rekap_upah.xlsx', {
-        Snapshot: rows,
-        'Total per Rumah': rumahSheet,
-        'Total per Hari': hariSheet
+        Snapshot: rows
       });
       showToast('File XLSX dibuat', 'success');
     });
@@ -446,9 +380,7 @@
         No: idx + 1,
         Key: item.key,
         Periode: `${item.start} s/d ${item.end}`,
-        Rumah: item.rumah,
         TotalUpah: item.total,
-        TotalHari: item.totalDays,
         UpdatedAt: item.updatedAt
       }));
       utils.toCSV('rekap_upah.csv', rows);


### PR DESCRIPTION
## Summary
- add a resolver that coalesces the current period start/end from the form, storage, or local history so metadata rows have actual dates
- reuse the resolver for CSV exports and persistence so the WhatsApp text and saved snapshots stay in sync
- normalize the resolved period dates to yyyy-mm-dd before saving history or exporting so the CSV metadata and WhatsApp text include formatted dates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e74af71fec8333bb113e34d86b6da1