### PR TITLE
Align snapshot storage with KV list refresh

### DIFF
--- a/assets/js/upah-core.js
+++ b/assets/js/upah-core.js
@@ -117,7 +117,13 @@ export function ensureApiClient() {
         return API.list(prefix, cursor, limit);
       },
       async listSnapshots(prefix, cursor = '', limit = 50) {
-        return API.list(prefix, cursor, limit);
+        return API.listSnapshots(prefix, cursor, limit);
+      },
+      async refreshSnapshotList(prefix = 'ut:snap:') {
+        return API.refreshSnapshots(prefix);
+      },
+      onSnapshotListChange(listener) {
+        return API.onSnapshotListChange(listener);
       }
     };
   }

--- a/form.html
+++ b/form.html
@@ -2441,13 +2441,22 @@ document.addEventListener('DOMContentLoaded', () => {
         updatedAt: nowISO
       };
 
+      const periodeLabel = payload.start && payload.end
+        ? `${payload.start} s/d ${payload.end}`
+        : (payload.start || payload.end || '');
+      const judul = [payload.rumah || '', periodeLabel].filter(Boolean).join(' • ') || 'Snapshot';
+
       const meta = {
-        start: payload.start || null,
-        end: payload.end || null,
-        rumah: payload.rumah || null,
+        periodStart: payload.start || null,
+        periodEnd: payload.end || null,
+        lokasi: payload.rumah || null,
+        judul,
         total: summary.total,
         totalDays: summary.totalDays,
-        updatedAt: nowISO
+        updatedAt: nowISO,
+        start: payload.start || null,
+        end: payload.end || null,
+        rumah: payload.rumah || null
       };
 
       let key = state.currentKey;

--- a/functions/api/list.js
+++ b/functions/api/list.js
@@ -1,101 +1,140 @@
 import { getKVBinding } from './_kv';
 
-const JSON_HEADERS = {
-  'Content-Type': 'application/json',
+const BASE_HEADERS = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type'
+  'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Cache-Control': 'no-store'
 };
 
-const DEFAULT_LIMIT = 100;
-const MAX_LIMIT = 500;
+const JSON_HEADERS = {
+  ...BASE_HEADERS,
+  'Content-Type': 'application/json; charset=utf-8'
+};
 
-function json(data, { status = 200, headers = {} } = {}) {
-  return new Response(JSON.stringify(data), {
+export const onRequestOptions = () =>
+  new Response(null, {
+    status: 204,
+    headers: BASE_HEADERS
+  });
+
+const PAGE_LIMIT = 200;
+const MAX_ITEMS = 1000;
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
     status,
-    headers: { ...JSON_HEADERS, ...headers }
+    headers: JSON_HEADERS
   });
 }
 
 export async function onRequest({ request, env }) {
   if (request.method === 'OPTIONS') {
-    return json({}, { status: 204 });
+    return onRequestOptions();
   }
 
   if (request.method.toUpperCase() !== 'GET') {
-    return json({ ok: false, error: 'Method not allowed' }, { status: 405 });
+    return json({ ok: false, error: 'Method not allowed' }, 405);
   }
 
   const { kv } = getKVBinding(env);
   if (!kv) {
-    return json({ ok: false, error: 'KV binding UPAH_KV not found' }, { status: 500 });
+    return json({ ok: false, error: 'KV binding UPAH_KV not found' }, 500);
   }
 
   const url = new URL(request.url);
-  const prefix = url.searchParams.get('prefix') ?? 'ut:snap:';
-  const cursor = url.searchParams.get('cursor') || undefined;
-  const withValues = url.searchParams.get('values') === '1';
-
-  let limit = Number.parseInt(url.searchParams.get('limit') || `${DEFAULT_LIMIT}`, 10);
-  if (!Number.isFinite(limit) || limit <= 0) {
-    limit = DEFAULT_LIMIT;
-  }
-  limit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+  const prefix = url.searchParams.get('prefix') || 'ut:snap:';
+  let cursor = url.searchParams.get('cursor') || undefined;
 
   try {
-    const listOptions = { prefix, limit };
-    if (cursor) {
-      listOptions.cursor = cursor;
-    }
-
-    const iter = await kv.list(listOptions);
-    const keys = [];
     const items = [];
+    let safety = 0;
+    do {
+      const listOptions = { prefix };
+      if (cursor) {
+        listOptions.cursor = cursor;
+      }
+      listOptions.limit = PAGE_LIMIT;
 
-    for (const entry of iter.keys || []) {
-      const fallbackMeta = normaliseMeta(entry.metadata);
-      let resolvedMeta = fallbackMeta;
-      let value;
-
-      if (withValues) {
-        const detail = await kv.getWithMetadata(entry.name, { type: 'json' });
-        value = detail?.value ?? null;
-        const metaFromDetail = normaliseMeta(detail?.metadata);
-        if (Object.keys(metaFromDetail).length > 0) {
-          resolvedMeta = metaFromDetail;
+      const page = await kv.list(listOptions);
+      for (const entry of page.keys || []) {
+        const meta = await resolveMeta(kv, entry);
+        items.push({ key: entry.name, meta });
+        if (items.length >= MAX_ITEMS) {
+          break;
         }
       }
 
-      const keyInfo = { name: entry.name, metadata: resolvedMeta, meta: resolvedMeta };
-      keys.push(keyInfo);
-
-      const item = { key: entry.name, name: entry.name, metadata: resolvedMeta, meta: resolvedMeta };
-      if (withValues) {
-        item.value = value;
+      if (items.length >= MAX_ITEMS || page.list_complete) {
+        cursor = null;
+      } else {
+        cursor = page.cursor || null;
       }
-      items.push(item);
-    }
 
-    const nextCursor = iter.list_complete ? null : (iter.cursor || null);
+      safety += 1;
+      if (!cursor || safety > 50) {
+        cursor = null;
+      }
+    } while (cursor);
 
-    return json({
-      ok: true,
-      prefix,
-      count: items.length,
-      cursor: nextCursor,
-      list_complete: Boolean(iter.list_complete),
-      items,
-      keys
-    });
+    items.sort((a, b) => getTimestamp(b.meta) - getTimestamp(a.meta));
+
+    return json({ items, cursor: null });
   } catch (err) {
     console.error('api/list error', err);
-    return json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+    return json({ ok: false, error: 'Internal Server Error' }, 500);
   }
+}
+
+async function resolveMeta(kv, entry) {
+  const initial = entry?.metadata && typeof entry.metadata === 'object' ? entry.metadata : null;
+  if (initial && Object.keys(initial).length > 0) {
+    return normaliseMeta(initial);
+  }
+  const detail = await kv.getWithMetadata(entry.name);
+  return normaliseMeta(detail?.metadata);
 }
 
 function normaliseMeta(meta) {
   if (!meta || typeof meta !== 'object') {
     return {};
   }
-  return { ...meta };
+  const cleaned = { ...meta };
+  if (!cleaned.updatedAt && cleaned.updated_at) {
+    cleaned.updatedAt = cleaned.updated_at;
+  }
+  if (!cleaned.periodStart && cleaned.start) {
+    cleaned.periodStart = cleaned.start;
+  }
+  if (!cleaned.periodEnd && cleaned.end) {
+    cleaned.periodEnd = cleaned.end;
+  }
+  if (!cleaned.lokasi && cleaned.rumah) {
+    cleaned.lokasi = cleaned.rumah;
+  }
+  if (cleaned.periodStart && typeof cleaned.periodStart === 'string') {
+    cleaned.periodStart = cleaned.periodStart.slice(0, 10);
+  }
+  if (cleaned.periodEnd && typeof cleaned.periodEnd === 'string') {
+    cleaned.periodEnd = cleaned.periodEnd.slice(0, 10);
+  }
+  return cleaned;
+}
+
+function getTimestamp(meta = {}) {
+  const updated = meta?.updatedAt;
+  if (updated) {
+    const parsed = Date.parse(updated);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  const created = meta?.created || meta?.createdAt;
+  if (created) {
+    const parsed = Date.parse(created);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
 }

--- a/functions/api/state.js
+++ b/functions/api/state.js
@@ -1,20 +1,31 @@
 import { getKVBinding } from './_kv';
 
-const JSON_HEADERS = {
-  'Content-Type': 'application/json',
+const BASE_HEADERS = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Methods': 'GET,POST,DELETE,OPTIONS',
-  'Access-Control-Allow-Headers': 'Content-Type'
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Cache-Control': 'no-store'
 };
 
-const MAX_VALUE_BYTES = 200 * 1024; // ~200KB default guard
-const MAX_META_BYTES = 1024; // Cloudflare KV metadata limit
-const encoder = new TextEncoder();
+const JSON_HEADERS = {
+  ...BASE_HEADERS,
+  'Content-Type': 'application/json; charset=utf-8'
+};
 
-function json(data, { status = 200, headers = {} } = {}) {
-  return new Response(JSON.stringify(data), {
+export const onRequestOptions = () =>
+  new Response(null, {
+    status: 204,
+    headers: BASE_HEADERS
+  });
+
+const encoder = new TextEncoder();
+const MAX_VALUE_BYTES = 200 * 1024;
+const MAX_META_BYTES = 1024;
+
+function json(body, status = 200) {
+  return new Response(JSON.stringify(body), {
     status,
-    headers: { ...JSON_HEADERS, ...headers }
+    headers: JSON_HEADERS
   });
 }
 
@@ -24,72 +35,73 @@ export async function onRequest(context) {
   const method = request.method.toUpperCase();
   const keyParam = url.searchParams.get('key');
 
-  if (method === 'OPTIONS') {
-    return json({}, { status: 204 });
-  }
-
   const { kv } = getKVBinding(env);
   if (!kv) {
-    return json({ ok: false, error: 'KV binding UPAH_KV not found' }, { status: 500 });
+    return json({ ok: false, error: 'KV binding UPAH_KV not found' }, 500);
+  }
+
+  if (method === 'OPTIONS') {
+    return onRequestOptions();
   }
 
   try {
     if (method === 'GET') {
       if (!keyParam) {
-        return json({ ok: false, error: 'key required' }, { status: 400 });
+        return json({ ok: false, error: 'key required' }, 400);
       }
 
       const result = await kv.getWithMetadata(keyParam, { type: 'json' });
       if (!result) {
-        return json({ ok: false, error: 'Not found' }, { status: 404 });
+        return json({ ok: false, error: 'Not found' }, 404);
       }
 
-      const meta = normaliseMeta(result?.metadata);
-      return json({ ok: true, key: keyParam, value: result?.value ?? null, meta });
+      const meta = normaliseStoredMeta(result.metadata);
+      return json({ ok: true, key: keyParam, value: result.value ?? null, meta });
     }
 
     if (method === 'POST') {
-      const payload = await safeJson(request);
+      const payload = await readJsonSafe(request);
       const key = payload?.key || keyParam;
       if (!key) {
-        return json({ ok: false, error: 'key required' }, { status: 400 });
+        return json({ ok: false, error: 'key required' }, 400);
       }
 
-      const value = payload?.value ?? null;
-      const meta = withMeta(payload?.meta);
-
-      const encodedValue = JSON.stringify(value);
+      const encodedValue = JSON.stringify(payload?.value ?? {});
       const valueSize = encoder.encode(encodedValue).byteLength;
       if (valueSize > MAX_VALUE_BYTES) {
-        return json({ ok: false, error: 'Value too large' }, { status: 413 });
+        return json({ ok: false, error: 'Value too large' }, 413);
       }
 
-      const metaSize = encoder.encode(JSON.stringify(meta)).byteLength;
+      const incomingMeta = payload?.meta && typeof payload.meta === 'object' ? payload.meta : {};
+      const preparedMeta = prepareMeta(incomingMeta);
+      const metaSize = encoder.encode(JSON.stringify(preparedMeta)).byteLength;
       if (metaSize > MAX_META_BYTES) {
-        return json({ ok: false, error: 'Meta too large' }, { status: 413 });
+        return json({ ok: false, error: 'Meta too large' }, 413);
       }
 
-      await kv.put(key, encodedValue, { metadata: meta });
+      const existing = await kv.getWithMetadata(key);
+      await kv.put(key, encodedValue, { metadata: preparedMeta });
 
-      return json({ ok: true, key, meta });
+      const statusCode = existing ? 200 : 201;
+      return json({ ok: true, key, meta: preparedMeta }, statusCode);
     }
 
     if (method === 'DELETE') {
       if (!keyParam) {
-        return json({ ok: false, error: 'key required' }, { status: 400 });
+        return json({ ok: false, error: 'key required' }, 400);
       }
       await kv.delete(keyParam);
-      return json({ ok: true, key: keyParam });
+      return json({ ok: true });
     }
 
-    return json({ ok: false, error: 'Method not allowed' }, { status: 405 });
+    return json({ ok: false, error: 'Method not allowed' }, 405);
   } catch (err) {
     console.error('api/state error', err);
-    return json({ ok: false, error: 'Internal Server Error' }, { status: 500 });
+    return json({ ok: false, error: 'Internal Server Error' }, 500);
   }
 }
 
-async function safeJson(request) {
+async function readJsonSafe(request) {
   try {
     return await request.json();
   } catch (err) {
@@ -97,17 +109,60 @@ async function safeJson(request) {
   }
 }
 
-function withMeta(meta) {
-  const base = normaliseMeta(meta);
-  if (!base.updatedAt) {
-    base.updatedAt = new Date().toISOString();
-  }
-  return base;
+function prepareMeta(meta = {}) {
+  const nowISO = new Date().toISOString();
+  const base = { ...(meta && typeof meta === 'object' ? meta : {}) };
+
+  const periodStart = toDateString(base.periodStart ?? base.start ?? base.period_start ?? '');
+  const periodEnd = toDateString(base.periodEnd ?? base.end ?? base.period_end ?? '');
+  const lokasi = toText(base.lokasi ?? base.rumah ?? base.location ?? '');
+  const judul = toText(
+    base.judul ||
+      (lokasi && periodStart && periodEnd
+        ? `${lokasi} (${periodStart} – ${periodEnd})`
+        : periodStart && periodEnd
+          ? `${periodStart} – ${periodEnd}`
+          : lokasi || 'Snapshot')
+  );
+
+  return {
+    ...base,
+    periodStart: periodStart || null,
+    periodEnd: periodEnd || null,
+    lokasi: lokasi || null,
+    judul,
+    updatedAt: nowISO
+  };
 }
 
-function normaliseMeta(meta) {
+function normaliseStoredMeta(meta) {
   if (!meta || typeof meta !== 'object') {
     return {};
   }
-  return { ...meta };
+  const cleaned = { ...meta };
+  if (cleaned.periodStart && typeof cleaned.periodStart === 'string') {
+    cleaned.periodStart = cleaned.periodStart;
+  }
+  if (cleaned.periodEnd && typeof cleaned.periodEnd === 'string') {
+    cleaned.periodEnd = cleaned.periodEnd;
+  }
+  if (cleaned.lokasi && typeof cleaned.lokasi === 'string') {
+    cleaned.lokasi = cleaned.lokasi;
+  }
+  if (cleaned.judul && typeof cleaned.judul === 'string') {
+    cleaned.judul = cleaned.judul;
+  }
+  return cleaned;
+}
+
+function toDateString(value) {
+  if (!value) return '';
+  const str = String(value).trim();
+  if (!str) return '';
+  return str.slice(0, 10);
+}
+
+function toText(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).trim();
 }

--- a/index.html
+++ b/index.html
@@ -102,18 +102,14 @@
 
     const api = ensureApiClient();
 
-    const NEW_COUNTER_KEY = 'upahTukang:newCounter';
-
     const YEAR = new Date().getFullYear();
     document.getElementById('year').textContent = YEAR;
 
     const state = {
-      currentCursor: '',
-      nextCursor: '',
-      history: [],
-      cache: new Map(),
-      loading: false,
-      listComplete: false
+      items: [],
+      page: 1,
+      perPage: 10,
+      loading: false
     };
 
     const tableBody = document.getElementById('listBody');
@@ -121,144 +117,131 @@
     const emptyState = document.getElementById('emptyState');
     const cursorInfo = document.getElementById('cursorInfo');
     const listInfo = document.getElementById('listInfo');
+    const btnPrev = document.getElementById('btnPrev');
+    const btnNext = document.getElementById('btnNext');
 
-    function buildKeyInfo(key, metadata = {}) {
-      const { start, end, rumah } = utils.parseSnapshotKey(key);
-      const periode = start && end ? `${start} – ${end}` : 'Tidak diketahui';
-      const rumahLabel = rumah || metadata.rumah || '—';
-      const total = metadata.total ?? metadata.totalUpah ?? null;
-      const updatedAt = metadata.updatedAt ? new Date(metadata.updatedAt).toLocaleString('id-ID') : '—';
-      const totalLabel = total != null ? utils.formatRupiah(total) : '—';
-      return { periode, rumah: rumahLabel, updatedAt, totalLabel };
+    const normaliseItem = (entry) => {
+      const key = entry?.key || entry?.name || '';
+      if (!key) return null;
+      const meta = entry?.meta && typeof entry.meta === 'object' ? entry.meta : (entry?.metadata || {});
+      const parsed = utils.parseSnapshotKey(key);
+      const start = meta.periodStart || meta.start || parsed.start || '';
+      const end = meta.periodEnd || meta.end || parsed.end || '';
+      const rumah = meta.lokasi || meta.rumah || parsed.rumah || '';
+      const updatedAt = meta.updatedAt || meta.updated_at || '';
+      const total = meta.total ?? meta.totalUpah ?? meta.total_upah ?? null;
+      return { key, start, end, rumah, updatedAt, total, meta };
+    };
+
+    const handleSnapshotList = ({ items }) => {
+      const list = Array.isArray(items) ? items : [];
+      state.items = list
+        .map(normaliseItem)
+        .filter(Boolean)
+        .sort((a, b) => {
+          const tb = new Date(b.updatedAt || 0).getTime();
+          const ta = new Date(a.updatedAt || 0).getTime();
+          return tb - ta;
+        });
+      state.page = 1;
+      state.loading = false;
+      render();
+    };
+
+    const unsubscribe = api.onSnapshotListChange(handleSnapshotList);
+
+    function paginate() {
+      const startIndex = (state.page - 1) * state.perPage;
+      return state.items.slice(startIndex, startIndex + state.perPage);
     }
 
-    function renderRows(keys = []) {
+    function render() {
+      const rows = paginate();
       tableBody.innerHTML = '';
-      keys.forEach(({ name, metadata = {} }) => {
-        const info = buildKeyInfo(name, metadata || {});
+
+      if (!state.items.length) {
+        skeleton.classList.add('hidden');
+        emptyState.classList.remove('hidden');
+        listInfo.textContent = 'Belum ada snapshot';
+        cursorInfo.textContent = '';
+        btnPrev.disabled = true;
+        btnNext.disabled = true;
+        return;
+      }
+
+      emptyState.classList.add('hidden');
+      skeleton.classList.add('hidden');
+
+      rows.forEach((item) => {
+        const periode = item.start && item.end ? `${item.start} – ${item.end}` : 'Tidak diketahui';
+        const rumahLabel = item.rumah || '—';
+        const totalLabel = item.total != null ? utils.formatRupiah(item.total) : '—';
+        const updatedLabel = item.updatedAt ? new Date(item.updatedAt).toLocaleString('id-ID') : '—';
         const tr = document.createElement('tr');
         tr.className = 'transition hover:bg-slate-50';
         tr.dataset.testid = 'snapshot-row';
         tr.innerHTML = `
           <td class="py-3 pr-4 align-top">
-            <div class="font-medium text-slate-800">${info.periode}</div>
-            <div class="text-xs text-slate-400">${name}</div>
+            <div class="font-medium text-slate-800">${periode}</div>
+            <div class="text-xs text-slate-400">${item.key}</div>
           </td>
-          <td class="py-3 pr-4 align-top text-slate-700">${info.rumah}</td>
-          <td class="py-3 pr-4 align-top text-right font-medium text-slate-800">${info.totalLabel}</td>
-          <td class="py-3 pr-4 align-top text-slate-600">${info.updatedAt}</td>
+          <td class="py-3 pr-4 align-top text-slate-700">${rumahLabel}</td>
+          <td class="py-3 pr-4 align-top text-right font-medium text-slate-800">${totalLabel}</td>
+          <td class="py-3 pr-4 align-top text-slate-600">${updatedLabel}</td>
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
-              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form.html?key=${encodeURIComponent(name)}">Buka</a>
-              <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="dashboard-delete" data-key="${name}">Hapus</button>
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form.html?key=${encodeURIComponent(item.key)}">Buka</a>
+              <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="dashboard-delete" data-key="${item.key}">Hapus</button>
             </div>
           </td>
         `;
         tableBody.appendChild(tr);
       });
+
+      const total = state.items.length;
+      const totalPages = Math.max(1, Math.ceil(total / state.perPage));
+      const startIndex = (state.page - 1) * state.perPage;
+      const endIndex = Math.min(total, startIndex + rows.length);
+
+      listInfo.textContent = `Menampilkan ${startIndex + 1}–${endIndex} dari ${total} snapshot`;
+      cursorInfo.textContent = `Halaman ${state.page} dari ${totalPages}`;
+      btnPrev.disabled = state.page <= 1;
+      btnNext.disabled = state.page >= totalPages;
     }
 
-    function resetPagination() {
-      state.currentCursor = '';
-      state.nextCursor = '';
-      state.listComplete = false;
-      state.history = [];
-      state.cache.clear();
-    }
-
-    async function showPage(cursor = '') {
-      if (state.loading) return false;
-      const cached = state.cache.get(cursor);
-      if (!cached) {
-        tableBody.innerHTML = '';
-        skeleton.classList.remove('hidden');
-        listInfo.textContent = 'Memuat data...';
-      } else {
-        skeleton.classList.add('hidden');
-      }
-      emptyState.classList.add('hidden');
-
-      try {
-        state.loading = true;
-        const payload = cached || await api.listSnapshots('ut:snap:', cursor, 15);
-        if (!cached) {
-          state.cache.set(cursor, payload);
-        }
-        const { keys = [], cursor: nextCursor = '', list_complete } = payload;
-        skeleton.classList.add('hidden');
-
-        if (!keys.length && !cursor && !nextCursor) {
-          tableBody.innerHTML = '';
-          emptyState.classList.remove('hidden');
-          listInfo.textContent = 'Belum ada snapshot';
-          cursorInfo.textContent = '';
-          state.currentCursor = '';
-          state.nextCursor = '';
-          state.listComplete = true;
-          document.getElementById('btnPrev').disabled = true;
-          document.getElementById('btnNext').disabled = true;
-          return true;
-        }
-
-        renderRows(keys.slice(0, 10));
-        state.currentCursor = cursor;
-        state.nextCursor = nextCursor || '';
-        state.listComplete = !!list_complete || (!state.nextCursor && keys.length < 15);
-
-        cursorInfo.textContent = state.listComplete
-          ? 'Sudah halaman terakhir'
-          : (state.nextCursor ? `Cursor ${state.nextCursor.slice(0, 8)}…` : '');
-        listInfo.textContent = `${Math.min(keys.length, 10)} dari ${keys.length} entri halaman ini`;
-
-        document.getElementById('btnPrev').disabled = state.history.length === 0;
-        document.getElementById('btnNext').disabled = state.listComplete;
-        return true;
-      } catch (err) {
-        skeleton.classList.add('hidden');
-        emptyState.classList.add('hidden');
-        showToast(formatError(err), 'error');
-        listInfo.textContent = 'Gagal memuat data';
-        return false;
-      } finally {
-        state.loading = false;
-      }
-    }
-
-    document.getElementById('btnPrev').addEventListener('click', async () => {
-      if (!state.history.length) return;
-      const target = state.history[state.history.length - 1];
-      const ok = await showPage(target);
-      if (ok) {
-        state.history.pop();
-      }
+    btnPrev.addEventListener('click', () => {
+      if (state.page <= 1) return;
+      state.page -= 1;
+      render();
     });
 
-    document.getElementById('btnNext').addEventListener('click', async () => {
-      if (state.listComplete && !state.nextCursor) return;
-      const target = state.nextCursor;
-      const previous = state.currentCursor;
-      const ok = await showPage(target);
-      if (ok) {
-        state.history.push(previous);
-      }
+    btnNext.addEventListener('click', () => {
+      const totalPages = Math.max(1, Math.ceil(state.items.length / state.perPage));
+      if (state.page >= totalPages) return;
+      state.page += 1;
+      render();
     });
 
     document.addEventListener('click', async (event) => {
       const target = event.target;
       if (target.matches('button[data-key]')) {
         const key = target.getAttribute('data-key');
-        const confirmed = window.confirm('Hapus snapshot ini? Data tidak dapat dikembalikan.');
-        if (!confirmed) return;
+        if (!key) return;
+        if (!window.confirm('Hapus snapshot ini? Data tidak dapat dikembalikan.')) return;
         try {
+          state.loading = true;
+          skeleton.classList.remove('hidden');
           await api.deleteKey(key);
           showToast('Snapshot dihapus', 'success');
-          resetPagination();
-          await showPage('');
         } catch (err) {
+          state.loading = false;
+          skeleton.classList.add('hidden');
           showToast(formatError(err), 'error');
         }
       }
     });
+
+    const NEW_COUNTER_KEY = 'upahTukang:newCounter';
 
     function nextNewIndex() {
       try {
@@ -282,7 +265,27 @@
     document.getElementById('btnNew').addEventListener('click', openNewForm);
     document.getElementById('ctaNew').addEventListener('click', openNewForm);
 
-    showPage('');
+    const reload = async () => {
+      if (state.loading) return;
+      state.loading = true;
+      skeleton.classList.remove('hidden');
+      emptyState.classList.add('hidden');
+      listInfo.textContent = 'Memuat data...';
+      cursorInfo.textContent = '';
+      try {
+        await api.refreshSnapshotList('ut:snap:');
+      } catch (err) {
+        state.loading = false;
+        skeleton.classList.add('hidden');
+        showToast(formatError(err), 'error');
+      }
+    };
+
+    await reload();
+
+    window.addEventListener('pagehide', () => {
+      unsubscribe();
+    });
   </script>
 </body>
 </html>

--- a/rekap.html
+++ b/rekap.html
@@ -103,19 +103,16 @@
     import { utils, showToast, formatError, ensureApiClient } from './assets/js/upah-core.js';
 
     const api = ensureApiClient();
-
     const AUTO_REFRESH_MS = 15000;
 
-    const YEAR = new Date().getFullYear();
-    document.getElementById('year').textContent = YEAR;
+    document.getElementById('year').textContent = new Date().getFullYear();
 
     const state = {
-      all: [],
+      items: [],
       filtered: [],
       page: 1,
       perPage: 20,
       loading: false,
-      rawKeys: [],
       detailCache: new Map()
     };
 
@@ -126,6 +123,8 @@
     const totalInfo = document.getElementById('totalInfo');
     const pageInfo = document.getElementById('pageInfo');
     const cursorInfo = document.getElementById('cursorInfo');
+    const btnPrev = document.getElementById('btnPrev');
+    const btnNext = document.getElementById('btnNext');
 
     const filterControls = {
       start: document.getElementById('filterStart'),
@@ -133,126 +132,90 @@
       search: document.getElementById('filterSearch')
     };
 
-    async function fetchAll({ silent = false } = {}) {
-      if (state.loading) return;
-      state.loading = true;
-      state.rawKeys = [];
-      tableSkeleton.classList.remove('hidden');
-      tableWrap.classList.add('hidden');
-      emptyState.classList.add('hidden');
-      totalInfo.textContent = 'Memuat data...';
-      let cursor = '';
-      let safety = 0;
-      try {
-        do {
-          const res = await api.listSnapshots('ut:snap:', cursor, 100);
-          state.rawKeys.push(...(res.keys || []));
-          cursor = res.cursor || '';
-          safety += 1;
-          if (res.list_complete || !cursor || safety > 20) break;
-        } while (true);
+    const normaliseRecord = (entry) => {
+      const key = entry?.key || entry?.name || '';
+      if (!key) return null;
+      const meta = entry?.meta && typeof entry.meta === 'object' ? entry.meta : (entry?.metadata || {});
+      const parsed = utils.parseSnapshotKey(key);
+      const start = meta.periodStart || meta.start || parsed.start || '';
+      const end = meta.periodEnd || meta.end || parsed.end || '';
+      const rumah = meta.lokasi || meta.rumah || parsed.rumah || '';
+      const updatedAt = meta.updatedAt || meta.updated_at || '';
+      const total = meta.total ?? meta.totalUpah ?? meta.total_upah ?? null;
+      const totalDays = meta.totalDays ?? meta.totalHari ?? meta.total_hari ?? null;
+      const judul = meta.judul || '';
+      return { key, start, end, rumah, lokasi: rumah, updatedAt, total, totalDays, meta: { ...meta, judul } };
+    };
 
-        const keep = new Set(state.rawKeys.map((entry) => entry.name));
-        Array.from(state.detailCache.keys()).forEach((key) => {
-          if (!keep.has(key)) state.detailCache.delete(key);
-        });
+    const handleSnapshotList = async ({ items }) => {
+      const list = Array.isArray(items) ? items : [];
+      const mapped = list.map(normaliseRecord).filter(Boolean);
+      const keepKeys = new Set(mapped.map((item) => item.key));
 
-        await enrichRecords();
-        applyFilter();
-        if (!silent) {
-          showToast('Data rekap diperbarui', 'success');
+      Array.from(state.detailCache.keys()).forEach((key) => {
+        if (!keepKeys.has(key)) {
+          state.detailCache.delete(key);
         }
-      } catch (err) {
-        showToast(formatError(err), 'error');
-        tableSkeleton.classList.add('hidden');
-      } finally {
-        state.loading = false;
-      }
-    }
+      });
 
-    async function enrichRecords() {
-      const records = [];
       const needFetch = [];
 
-      state.rawKeys.forEach((entry) => {
-        const { name, metadata = {} } = entry;
-        const parsed = utils.parseSnapshotKey(name);
-        const cached = state.detailCache.get(name);
-        const record = {
-          key: name,
-          start: metadata.start || parsed.start || '',
-          end: metadata.end || parsed.end || '',
-          rumah: metadata.rumah || parsed.rumah || '',
-          updatedAt: metadata.updatedAt || '',
-          total: metadata.total ?? metadata.totalUpah ?? null,
-          totalDays: metadata.totalDays ?? null,
-          meta: metadata
-        };
-
+      mapped.forEach((record) => {
+        const cached = state.detailCache.get(record.key);
         if (cached) {
           Object.assign(record, cached);
         } else if (record.total == null || record.totalDays == null) {
           needFetch.push(record);
         }
-
-        records.push(record);
       });
 
       if (needFetch.length) {
-        const concurrency = Math.min(4, needFetch.length);
-        let index = 0;
-        const workers = Array.from({ length: concurrency }, () => (async () => {
-          while (index < needFetch.length) {
-            const currentIndex = index++;
-            const item = needFetch[currentIndex];
-            if (!item) break;
+        await Promise.all(
+          needFetch.map(async (record) => {
             try {
-              const res = await api.loadData(item.key);
-              const rows = res?.value?.rows || [];
-              const detail = {
-                total: utils.sumRows(rows),
-                totalDays: utils.sumDays(rows),
-                start: res?.value?.start || item.start,
-                end: res?.value?.end || item.end,
-                rumah: res?.value?.rumah || item.rumah,
-                updatedAt: res?.meta?.updatedAt || item.updatedAt
-              };
-              Object.assign(item, detail);
-              state.detailCache.set(item.key, {
-                total: detail.total,
-                totalDays: detail.totalDays,
-                start: detail.start,
-                end: detail.end,
-                rumah: detail.rumah,
-                updatedAt: detail.updatedAt
-              });
+              const res = await api.loadData(record.key);
+              const value = res?.value || {};
+              const rows = value.rows || value.data?.rows || [];
+              const total = value.summary?.total ?? utils.sumRows(rows);
+              const totalDays = value.summary?.totalDays ?? utils.sumDays(rows);
+              const start = value.start || value.periodStart || record.start;
+              const end = value.end || value.periodEnd || record.end;
+              const rumah = value.rumah || value.lokasi || record.rumah;
+              const updatedAt = res?.meta?.updatedAt || record.updatedAt;
+              const detail = { total, totalDays, start, end, rumah, lokasi: rumah, updatedAt };
+              Object.assign(record, detail);
+              state.detailCache.set(record.key, detail);
             } catch (err) {
-              console.error('gagal load detail', item.key, err);
-              item.total = item.total ?? 0;
-              item.totalDays = item.totalDays ?? 0;
+              console.error('gagal load detail', record.key, err);
+              record.total = record.total ?? 0;
+              record.totalDays = record.totalDays ?? 0;
             }
-          }
-        })());
-        await Promise.all(workers);
+          })
+        );
       }
 
-      state.all = records.sort((a, b) => {
-        const dateA = new Date(a.updatedAt || 0).getTime();
-        const dateB = new Date(b.updatedAt || 0).getTime();
-        return dateB - dateA;
+      state.items = mapped.sort((a, b) => {
+        const tb = new Date(b.updatedAt || 0).getTime();
+        const ta = new Date(a.updatedAt || 0).getTime();
+        return tb - ta;
       });
-    }
+      applyFilter();
+      tableSkeleton.classList.add('hidden');
+      state.loading = false;
+    };
+
+    const unsubscribe = api.onSnapshotListChange(handleSnapshotList);
 
     function applyFilter() {
       const startVal = filterControls.start.value;
       const endVal = filterControls.end.value;
       const searchVal = filterControls.search.value.trim().toLowerCase();
 
-      state.filtered = state.all.filter((item) => {
+      state.filtered = state.items.filter((item) => {
         if (startVal && (!item.start || item.start < startVal)) return false;
         if (endVal && (!item.end || item.end > endVal)) return false;
         if (searchVal) {
-          const haystack = [item.key, item.rumah, item.start, item.end].join(' ').toLowerCase();
+          const haystack = [item.key, item.rumah, item.start, item.end, item.meta?.judul].join(' ').toLowerCase();
           if (!haystack.includes(searchVal)) return false;
         }
         return true;
@@ -269,18 +232,20 @@
     function render() {
       const rows = paginate();
       tableBody.innerHTML = '';
+
       if (!state.filtered.length) {
         tableSkeleton.classList.add('hidden');
         tableWrap.classList.add('hidden');
         emptyState.classList.remove('hidden');
-        totalInfo.textContent = '0 snapshot';
+        totalInfo.textContent = 'Belum ada snapshot';
         pageInfo.textContent = 'Halaman 0';
         cursorInfo.textContent = '';
         return;
       }
+
+      emptyState.classList.add('hidden');
       tableSkeleton.classList.add('hidden');
       tableWrap.classList.remove('hidden');
-      emptyState.classList.add('hidden');
 
       rows.forEach((item) => {
         const periode = item.start && item.end ? `${item.start} – ${item.end}` : '—';
@@ -306,20 +271,22 @@
       });
 
       const totalPages = Math.max(1, Math.ceil(state.filtered.length / state.perPage));
+      const startIndex = (state.page - 1) * state.perPage;
+      const endIndex = Math.min(state.filtered.length, startIndex + rows.length);
       pageInfo.textContent = `Halaman ${state.page} dari ${totalPages}`;
       totalInfo.textContent = `${state.filtered.length} snapshot`;
-      document.getElementById('btnPrev').disabled = state.page <= 1;
-      document.getElementById('btnNext').disabled = state.page >= totalPages;
-      cursorInfo.textContent = `${rows.length} baris ditampilkan`;
+      btnPrev.disabled = state.page <= 1;
+      btnNext.disabled = state.page >= totalPages;
+      cursorInfo.textContent = `Menampilkan ${startIndex + 1}–${endIndex} dari ${state.filtered.length} snapshot`;
     }
 
-    document.getElementById('btnPrev').addEventListener('click', () => {
+    btnPrev.addEventListener('click', () => {
       if (state.page <= 1) return;
       state.page -= 1;
       render();
     });
 
-    document.getElementById('btnNext').addEventListener('click', () => {
+    btnNext.addEventListener('click', () => {
       const totalPages = Math.max(1, Math.ceil(state.filtered.length / state.perPage));
       if (state.page >= totalPages) return;
       state.page += 1;
@@ -340,14 +307,16 @@
     document.addEventListener('click', async (event) => {
       if (event.target.matches('.btnDelete')) {
         const key = event.target.getAttribute('data-key');
+        if (!key) return;
         if (!window.confirm('Hapus snapshot ini?')) return;
         try {
+          state.loading = true;
+          tableSkeleton.classList.remove('hidden');
           await api.deleteKey(key);
           showToast('Snapshot dihapus', 'success');
-          state.rawKeys = state.rawKeys.filter((entry) => entry.name !== key);
-          state.all = state.all.filter((entry) => entry.key !== key);
-          applyFilter();
         } catch (err) {
+          state.loading = false;
+          tableSkeleton.classList.add('hidden');
           showToast(formatError(err), 'error');
         }
       }
@@ -387,13 +356,36 @@
       showToast('File CSV dibuat', 'success');
     });
 
-    fetchAll({ silent: true });
+    const reload = async ({ silent = false } = {}) => {
+      if (state.loading) return;
+      state.loading = true;
+      tableSkeleton.classList.remove('hidden');
+      tableWrap.classList.add('hidden');
+      emptyState.classList.add('hidden');
+      totalInfo.textContent = 'Memuat data...';
+      try {
+        await api.refreshSnapshotList('ut:snap:');
+        if (!silent) {
+          showToast('Data rekap diperbarui', 'success');
+        }
+      } catch (err) {
+        state.loading = false;
+        tableSkeleton.classList.add('hidden');
+        showToast(formatError(err), 'error');
+      }
+    };
+
+    await reload({ silent: true });
 
     setInterval(() => {
       if (document.hidden) return;
       if (state.loading) return;
-      fetchAll({ silent: true });
+      reload({ silent: true });
     }, AUTO_REFRESH_MS);
+
+    window.addEventListener('pagehide', () => {
+      unsubscribe();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the Cloudflare KV state endpoint enforces metadata requirements, consistent CORS headers, and proper create/update responses
- aggregate snapshot listings server-side and expose client helpers to refresh and subscribe to KV updates
- refresh dashboard and recap UIs automatically after saves/deletes with live data, improved loading states, and clearer empty states

## Testing
- no automated tests were run (project has no test suite)


------
https://chatgpt.com/codex/tasks/task_e_68ec5a6cd86483339c7fa3476d896ff1