### PR TITLE
Preserve form query parameters across clean URL redirects

### DIFF
--- a/form.html
+++ b/form.html
@@ -11,6 +11,29 @@
     import { api } from "./assets/js/config.js";
     window.UpahAPI = window.UpahAPI || api();
   </script>
+  <script>
+    (function preserveQueryOnCleanUrl(){
+      try {
+        if (typeof window === 'undefined' || !window.location) {
+          return;
+        }
+        const current = new URL(window.location.href);
+        const isHttp = current.protocol === 'http:' || current.protocol === 'https:';
+        if (!isHttp) return;
+        if (!/\/form\.html$/i.test(current.pathname)) return;
+        const search = current.search || '';
+        const hash = current.hash || '';
+        const nextPath = current.pathname.replace(/form\.html$/i, 'form');
+        const nextUrl = `${nextPath}${search}${hash}`;
+        const currentUrl = `${current.pathname}${search}${hash}`;
+        if (nextUrl !== currentUrl) {
+          window.location.replace(nextUrl);
+        }
+      } catch (err) {
+        console.warn('Gagal menormalkan URL form', err);
+      }
+    })();
+  </script>
   <style>
     :root {
       color-scheme: light dark;
@@ -2217,7 +2240,8 @@ document.addEventListener('DOMContentLoaded', () => {
   };
   // Auto "Kosongkan" when ?new=N
   (function(){
-    const p=new URLSearchParams(location.search); const hasNew=p.has('new')||(location.hash||'').toLowerCase().includes('new');
+    const currentUrl = new URL(window.location.href);
+    const p=currentUrl.searchParams; const hasNew=p.has('new')||(currentUrl.hash||'').toLowerCase().includes('new');
     if(!hasNew) return;
     function tryFns(){ for(const n of ['kosongkan','clearAll','resetAll','resetForm']){ const f=window[n]; if(typeof f==='function'){ const c=window.confirm; window.confirm=()=>true; try{f();} finally{window.confirm=c;} return true; } } return false; }
     function tryBtns(){ const c=Array.from(document.querySelectorAll('button,[role="button"],a')).filter(el=>/\b(kosongkan|hapus\s*semua|clear)\b/i.test(el.textContent||'')); if(c.length){ const C=window.confirm; window.confirm=()=>true; try{c[0].click();} finally{window.confirm=C;} return true; } return false; }
@@ -2298,8 +2322,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // 2) If opened with ?hist=YYYY-MM-DD, restore that periode's snapshot into current working storage
   (function maybeRestore(){
-    const p = new URLSearchParams(location.search);
-    const histStart = p.get('hist');
+    const currentUrl = new URL(window.location.href);
+    const histStart = currentUrl.searchParams.get('hist');
     if (!histStart) return;
     try {
       const snap = loadJSON(SNAP_PREFIX + histStart, null);
@@ -2735,7 +2759,8 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const API = await ensureApi();
-  const params = new URLSearchParams(location.search);
+  const currentUrl = new URL(window.location.href);
+  const params = currentUrl.searchParams;
 
   const escapeCSS = (value) => {
     if (window.CSS && typeof window.CSS.escape === 'function') {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
       </div>
       <nav class="flex items-center gap-2 text-sm">
         <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="rekap.html">Rekap</a>
-        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="form.html">Isi Form</a>
+        <a class="rounded-xl border border-slate-200 px-3 py-2 text-slate-600 hover:border-slate-300" href="form">Isi Form</a>
         <button id="btnNew" data-testid="dashboard-open-new" class="rounded-xl bg-orange-500 px-4 py-2 font-semibold text-white shadow-sm transition hover:bg-orange-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
       </nav>
     </div>
@@ -36,7 +36,7 @@
         <p class="mt-2 text-sm text-slate-500">Siapkan draft kosong dengan periode 7 hari ke depan. Data tersimpan otomatis di Cloudflare KV.</p>
         <div class="mt-4 flex flex-wrap gap-2">
           <button id="ctaNew" data-testid="dashboard-cta-new" class="rounded-xl bg-orange-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-orange-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-500">Form Baru</button>
-          <a href="form.html" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Lanjutkan Draft</a>
+          <a href="form" class="rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:border-slate-300">Lanjutkan Draft</a>
         </div>
       </article>
       <article class="rounded-2xl bg-white p-6 shadow-sm">
@@ -190,7 +190,7 @@
           <td class="py-3 pr-4 align-top text-slate-600">${updatedLabel}</td>
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
-              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form.html?key=${encodeURIComponent(item.key)}">Buka</a>
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form?key=${encodeURIComponent(item.key)}">Buka</a>
               <button class="rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="dashboard-delete" data-key="${item.key}">Hapus</button>
             </div>
           </td>
@@ -257,7 +257,7 @@
 
     function openNewForm() {
       const index = nextNewIndex();
-      const url = new URL('form.html', window.location.href);
+      const url = new URL('form', window.location.href);
       url.searchParams.set('new', String(index));
       window.location.href = url.toString();
     }

--- a/rekap.html
+++ b/rekap.html
@@ -262,7 +262,7 @@
           <td class="py-3 pr-4 align-top text-slate-600">${updated}</td>
           <td class="py-3 pl-4 text-right">
             <div class="flex justify-end gap-2">
-              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form.html?key=${encodeURIComponent(item.key)}">Buka</a>
+              <a class="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-700 hover:border-slate-300" href="form?key=${encodeURIComponent(item.key)}">Buka</a>
               <button class="btnDelete rounded-lg border border-red-200 px-3 py-1.5 text-xs font-semibold text-red-600 hover:border-red-300" data-testid="rekap-delete" data-key="${item.key}">Hapus</button>
             </div>
           </td>


### PR DESCRIPTION
## Summary
- add a guard on form.html that normalizes /form.html to /form while keeping any query and hash values intact
- switch form bootstrapping helpers to read URL parameters via the URL API instead of bare location.search
- point dashboard and rekap links at the clean /form path so query strings survive Cloudflare clean URL rewrites

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ec7039042c8333997876f40e647752